### PR TITLE
Fixes tests context ids

### DIFF
--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -209,32 +209,9 @@ pub(crate) fn api_method(
         }
     };
 
-    let input_attrs = &input.attrs;
-    let input_vis = &input.vis;
-    let input_defaultness = &input.defaultness;
-    let input_sig = &input.sig;
-    let input_block = &input.block;
-
     let expanded = quote! {
-        #[cfg(target_arch = "wasm32")]
         #[allow(dead_code)]
         #input
-
-        #[cfg(not(target_arch = "wasm32"))]
-        #(#input_attrs)*
-        #input_vis #input_defaultness #input_sig
-        {
-            let __id = ::ic_canister::ic_kit::ic::id();
-            let __caller = ::ic_canister::ic_kit::ic::caller();
-            ::ic_canister::ic_kit::inject::get_context().update_id(self.principal());
-            ::ic_canister::ic_kit::inject::get_context().update_caller(__id);
-
-            let result = #input_block;
-            ::ic_canister::ic_kit::inject::get_context().update_id(__id);
-            ::ic_canister::ic_kit::inject::get_context().update_caller(__caller);
-
-            result
-        }
 
         #export_function
 

--- a/ic-canister/ic-canister-macros/src/canister_call.rs
+++ b/ic-canister/ic-canister-macros/src/canister_call.rs
@@ -65,7 +65,16 @@ pub(crate) fn canister_call(input: TokenStream) -> TokenStream {
 
             #[cfg(not(target_arch = "wasm32"))]
             async {
-                #canister.#inner_method(#args).await
+                let __caller = ::ic_canister::ic_kit::ic::caller();
+                let __id = ::ic_canister::ic_kit::ic::id();
+                ::ic_canister::ic_kit::inject::get_context().update_caller(__id);
+                ::ic_canister::ic_kit::inject::get_context().update_id(#canister.principal());
+
+                let result = #canister.#inner_method(#args).await;
+
+                ::ic_canister::ic_kit::inject::get_context().update_caller(__caller);
+                ::ic_canister::ic_kit::inject::get_context().update_id(__id);
+                result
             }
         }
     };
@@ -93,8 +102,16 @@ pub(crate) fn canister_notify(input: TokenStream) -> TokenStream {
 
             #[cfg(not(target_arch = "wasm32"))]
             {
-                #canister.#inner_method(#args)
-            }
+                let __caller = ::ic_canister::ic_kit::ic::caller();
+                let __id = ::ic_canister::ic_kit::ic::id();
+                ::ic_canister::ic_kit::inject::get_context().update_caller(__id);
+                ::ic_canister::ic_kit::inject::get_context().update_id(#canister.principal());
+
+                let result = #canister.#inner_method(#args);
+
+                ::ic_canister::ic_kit::inject::get_context().update_caller(__caller);
+                ::ic_canister::ic_kit::inject::get_context().update_id(__id);
+                result            }
         }
     };
 

--- a/ic-canister/tests/canister_a/src/lib.rs
+++ b/ic-canister/tests/canister_a/src/lib.rs
@@ -63,43 +63,34 @@ mod tests {
 
     #[test]
     fn independent_states() {
-        MockContext::new().inject();
-        let curr_id = ic_canister::ic_kit::ic::id();
+        let ctx = MockContext::new().inject();
 
         let mut canister1 = CanisterAImpl::init_instance();
         let mut canister2 = CanisterAImpl::init_instance();
 
-        assert_eq!(ic_canister::ic_kit::ic::id(), curr_id);
-
+        ctx.update_id(canister1.principal());
         canister1.inc_counter(3);
+
+        ctx.update_id(canister2.principal());
         canister2.inc_counter(5);
 
+        ctx.update_id(canister1.principal());
         assert_eq!(canister1.get_counter(), 3);
+
+        ctx.update_id(canister2.principal());
         assert_eq!(canister2.get_counter(), 5);
 
+        ctx.update_id(canister1.principal());
         assert_eq!(
             CanisterAImpl::from_principal(canister1.principal()).get_counter(),
             3
         );
+
+        ctx.update_id(canister2.principal());
         assert_eq!(
             CanisterAImpl::from_principal(canister2.principal()).get_counter(),
             5
         );
-    }
-
-    #[test]
-    fn method_execution_context() {
-        let id = ic_canister::ic_kit::mock_principals::alice();
-        let caller = ic_canister::ic_kit::mock_principals::bob();
-
-        MockContext::new().with_id(id).with_caller(caller).inject();
-
-        let canister = CanisterAImpl::init_instance();
-        assert_eq!(canister.caller(), id, "wrong caller");
-        assert_eq!(canister.id(), canister.principal(), "wrong canister id");
-
-        assert_eq!(ic_canister::ic_kit::ic::id(), id);
-        assert_eq!(ic_canister::ic_kit::ic::caller(), caller);
     }
 
     #[tokio::test]

--- a/ic-canister/tests/canister_b/Cargo.toml
+++ b/ic-canister/tests/canister_b/Cargo.toml
@@ -15,7 +15,6 @@ canister_a = {path = "../canister_a", features = ["no_api"]}
 ic-storage = {path = "../../../ic-storage"}
 ic-canister = {path = "../../ic-canister"}
 ic-helpers = {path = "../../../ic-helpers"}
-ic-kit = { git = "https://github.com/infinity-swap/ic-kit", tag = "v0.4.5" }
 serde = "1.0"
 
 [dev-dependencies]

--- a/ic-canister/tests/canister_b/src/lib.rs
+++ b/ic-canister/tests/canister_b/src/lib.rs
@@ -107,6 +107,7 @@ impl CanisterA for CanisterB {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ic_canister::ic_kit::mock_principals::alice;
     use ic_canister::ic_kit::MockContext;
 
     fn get_canister_b(canister_a: Principal) -> CanisterB {
@@ -118,7 +119,7 @@ mod tests {
 
     #[tokio::test]
     async fn inter_canister_call() {
-        MockContext::new().inject();
+        let ctx = MockContext::new().with_id(alice()).inject();
 
         let canister_a = CanisterAImpl::init_instance();
         let canister_a2 = CanisterAImpl::init_instance();
@@ -128,9 +129,13 @@ mod tests {
         assert_eq!(canister_b.call_increment(5).await, 5);
         assert_eq!(canister_b.call_increment(15).await, 20);
         assert_eq!(canister_b.notify_increment(20).await, true);
+
+        ctx.update_id(canister_a.principal());
         assert_eq!(canister_a.__get_counter().await.unwrap(), 40);
 
         assert_eq!(canister_b2.notify_increment(100).await, true);
+
+        ctx.update_id(canister_a2.principal());
         assert_eq!(canister_a2.__get_counter().await.unwrap(), 100);
     }
 
@@ -141,7 +146,7 @@ mod tests {
         MockContext::new().with_id(id).with_caller(caller).inject();
 
         let canister_a = CanisterAImpl::init_instance();
-        let canister_b = CanisterB::init_instance();
+        let canister_b = CanisterB::from_principal(id);
         canister_b.init(canister_a.principal());
 
         assert_eq!(
@@ -157,7 +162,7 @@ mod tests {
 
         assert_eq!(
             canister_b.callers().await.0,
-            id,
+            caller,
             "invalid canister_b caller"
         );
         assert_eq!(
@@ -169,8 +174,8 @@ mod tests {
 
     #[tokio::test]
     async fn trait_methods() {
-        MockContext::new().inject();
-        let mut canister = CanisterB::init_instance();
+        MockContext::new().with_id(alice()).inject();
+        let mut canister = CanisterB::from_principal(alice());
 
         canister.inc_counter(13);
         canister.inc_counter(2);


### PR DESCRIPTION
It turns out that changing the text context ids on simple calls produces some undesirable side effects. For example, when a canister calls its own methods, with such approach the caller id and current canister id get messed up, which breaks many tests.

Instead, we rely on the test author to provide the test context when calling the canister methods directly, and make the `canister_call!` macros substitute the context. This approach is more transparent and less error prone.