### PR TITLE
[CPROD-899] Fix factory upgrade method

### DIFF
--- a/ic-canister/ic-canister-macros/src/derive.rs
+++ b/ic-canister/ic-canister-macros/src/derive.rs
@@ -153,6 +153,7 @@ pub fn derive_canister(input: TokenStream) -> TokenStream {
             __NEXT_ID.with(|v| v.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed).to_le_bytes())
         }
 
+        #[automatically_derived]
         impl #trait_name for #name {
             #[cfg(target_arch = "wasm32")]
             fn init_instance() -> Self {

--- a/ic-canister/ic-canister-macros/src/lib.rs
+++ b/ic-canister/ic-canister-macros/src/lib.rs
@@ -87,7 +87,7 @@ pub fn virtual_canister_notify(input: TokenStream) -> TokenStream {
 /// function. Thus, there's no need to mark it with `candid::candid_method` macro.
 #[proc_macro_attribute]
 pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
-    api::api_method("init", attr, item, true)
+    api::api_method("init", attr, item, true, true)
 }
 
 /// Marks the canister method as an API query method.
@@ -96,7 +96,7 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// function. Thus, there's no need to mark it with `candid::candid_method` macro.
 #[proc_macro_attribute]
 pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
-    api::api_method("query", attr, item, false)
+    api::api_method("query", attr, item, false, true)
 }
 
 /// Marks the canister method as an API update method.
@@ -105,7 +105,7 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// function. Thus, there's no need to mark it with `candid::candid_method` macro.
 #[proc_macro_attribute]
 pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
-    api::api_method("update", attr, item, false)
+    api::api_method("update", attr, item, false, true)
 }
 
 /// Marks the canister method as an `pre_upgrade` method.
@@ -114,7 +114,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// arguments or a return value.
 #[proc_macro_attribute]
 pub fn pre_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
-    api::api_method("pre_upgrade", attr, item, true)
+    api::api_method("pre_upgrade", attr, item, true, false)
 }
 
 /// Marks the canister method as an `post_upgrade` method.
@@ -123,7 +123,7 @@ pub fn pre_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// arguments or a return value.
 #[proc_macro_attribute]
 pub fn post_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
-    api::api_method("post_upgrade", attr, item, true)
+    api::api_method("post_upgrade", attr, item, true, false)
 }
 
 /// Generates IDL (Candid) definition of the canister.

--- a/ic-canister/tests/canister_a/src/lib.rs
+++ b/ic-canister/tests/canister_a/src/lib.rs
@@ -3,7 +3,7 @@ use ic_storage::stable::Versioned;
 use ic_storage::IcStorage;
 use std::{cell::RefCell, rc::Rc};
 
-use ic_canister::{generate_exports, query, update, Canister};
+use ic_canister::{generate_exports, query, update};
 
 #[derive(Default, CandidType, Deserialize, IcStorage)]
 pub struct StateA {
@@ -45,21 +45,13 @@ pub trait CanisterA: ic_canister::Canister {
     }
 }
 
-#[derive(Clone, Canister)]
-pub struct CanisterAImpl {
-    #[id]
-    principal: Principal,
-}
-
-impl CanisterA for CanisterAImpl {}
-
-generate_exports!(CanisterAImpl);
+generate_exports!(CanisterA, CanisterAImpl);
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ic_canister::canister_call;
     use ic_canister::ic_kit::MockContext;
+    use ic_canister::{canister_call, Canister};
 
     #[test]
     fn independent_states() {

--- a/ic-canister/tests/canister_b/src/lib.rs
+++ b/ic-canister/tests/canister_b/src/lib.rs
@@ -1,11 +1,10 @@
 use candid::{CandidType, Deserialize, Principal};
-use canister_a::CanisterAImpl;
 use ic_canister::{canister_call, canister_notify, virtual_canister_call, virtual_canister_notify};
 use ic_storage::IcStorage;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use canister_a::CanisterA;
+use canister_a::{CanisterA, CanisterAImpl};
 
 use ic_canister::{init, update, Canister};
 

--- a/ic-factory/src/api.rs
+++ b/ic-factory/src/api.rs
@@ -4,6 +4,7 @@ use candid::{Nat, Principal};
 use ic_canister::{generate_exports, query, update, AsyncReturn, Canister};
 
 use ic_helpers::management;
+use ic_helpers::management::WasmModule;
 
 use super::{error::FactoryError, FactoryState};
 
@@ -27,8 +28,6 @@ pub trait FactoryCanister: Canister + Sized {
         use ic_storage::IcStorage;
         FactoryState::get()
     }
-
-    fn get_canister_bytecode(&self) -> Option<Vec<u8>>;
 
     /// Returns the checksum of a wasm module in hex representation.
     #[query(trait = true)]
@@ -66,14 +65,15 @@ pub trait FactoryCanister: Canister + Sized {
 
     /// Upgrades canisters controller by the factory and returns a list of outdated canisters
     /// (in case an upgrade error occurs).
-    #[update(trait = true)]
-    fn upgrade<'a>(&'a mut self) -> AsyncReturn<Result<Vec<Principal>, FactoryError>> {
+    fn upgrade<'a>(
+        &'a mut self,
+        canister_bytecode: Option<WasmModule>,
+    ) -> AsyncReturn<Result<Vec<Principal>, FactoryError>> {
         // TODO: At the moment we do not do any security checks for this method, for even if there's
         // nothing to upgrade, it will just check all ic-helpers and do nothing else.
         // Later, we should add here (and in create_canister methods) a cycle check,
         // to make the caller to pay for the execution of this method.
 
-        let canister_bytecode = self.get_canister_bytecode();
         Box::pin(async move {
             let wasm = canister_bytecode.ok_or(FactoryError::CanisterWasmNotSet)?;
             let canisters = self.factory_state().borrow_mut().factory.canisters.clone();
@@ -218,16 +218,4 @@ pub trait FactoryCanister: Canister + Sized {
     }
 }
 
-#[derive(Clone, Canister)]
-pub struct FactoryExport {
-    #[id]
-    principal: Principal,
-}
-
-impl FactoryCanister for FactoryExport {
-    fn get_canister_bytecode(&self) -> Option<Vec<u8>> {
-        panic!("this implementation must not be used")
-    }
-}
-
-generate_exports!(FactoryExport);
+generate_exports!(FactoryCanister);


### PR DESCRIPTION
This commit fixes two issues:
1. The upgrade method in the factory API used `FactoryCanister::get_canister_bytecode` method. When such method is accessed from the FactoryExport struct (the one that is created just for trait APIs), which doesn't and cannot provide an implementation for this method. Instead, we remove this API method from the trait, leaving the actual method logic in the trait. This way, the factory structure implementing the `FactoryCanister` trait can have a one-line API method implementation that just calls the method in the trait providing the wasm code as an argument.
2. The `pre_upgrade` and `post_upgrade` macros reuse the code for other types of API methods, which included requesting the method call arguments from IC. Such a call resulted in a runtime error in a canister when trying to upgrade. We remove the arguments request for `pre_` and `post_upgrade` methods, and add compile-time check that those methods don't expect such arguments.

Due to the discovery of the first issue, it's now clear that a canister trait actually cannot safely have unimplemented methods (because of how the API methods are exported). This means that the export internal structure will always be an empty impl block, so we can move this struct generation into the `generate_exports` macro, which simplifies the usage of canister traits and prevent errors when writing export structs.