### PR TITLE
[CPROD-964] Refactor the canister factories and add upgrade state check

### DIFF
--- a/ic-factory/Cargo.toml
+++ b/ic-factory/Cargo.toml
@@ -33,6 +33,7 @@ ic-agent = { version = "0.16", optional = true }
 garcon = { version = "0.2", optional = true}
 libsecp256k1 = { version = "0.7", optional = false}
 k256 = { version = "0.10" }
+binread = "2.2"
 
 # This dependency is not used direcly, but we must enable `custom` feature for it to compile for wasm32 target.
 [target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]

--- a/ic-factory/src/api.rs
+++ b/ic-factory/src/api.rs
@@ -1,38 +1,25 @@
+use super::{error::FactoryError, FactoryState};
+use candid::{CandidType, Nat, Principal};
+use ic_canister::{
+    generate_exports, query, update, virtual_canister_call, AsyncReturn, Canister, PreUpdate,
+};
+use ic_cdk::export::candid::utils::ArgumentEncoder;
+use ic_helpers::candid_header::{validate_header, CandidHeader, TypeCheckResult};
+use ic_helpers::management;
+use ic_storage::stable::Versioned;
+use ic_storage::IcStorage;
+use std::collections::HashMap;
 use std::{cell::RefCell, rc::Rc};
 
-use candid::{Nat, Principal};
-use ic_canister::{generate_exports, query, update, AsyncReturn, Canister, PreUpdate};
-
-use ic_helpers::management;
-use ic_helpers::management::WasmModule;
-
-use super::{error::FactoryError, FactoryState};
-
-/// API methods that are added:
-/// * get_checksum
-/// * get_cycles
-/// * top_up
-/// * upgrade
-/// * version
-/// * length
-/// * get_all
-/// * get_icp_fee
-/// * set_icp_fee
-/// * get_icp_to
-/// * set_icp_to
-/// * get_controller
-/// * set_controller
-/// * refund_icp
 pub trait FactoryCanister: Canister + Sized + PreUpdate {
     fn factory_state(&self) -> Rc<RefCell<FactoryState>> {
-        use ic_storage::IcStorage;
         FactoryState::get()
     }
 
     /// Returns the checksum of a wasm module in hex representation.
     #[query(trait = true)]
-    fn get_checksum<'a>(&'a self) -> String {
-        self.factory_state().borrow().factory.checksum.to_string()
+    fn get_checksum(&self) -> Result<String, FactoryError> {
+        Ok(hex::encode(&self.factory_state().borrow().module()?.hash()))
     }
 
     /// Returns the cycles balances.
@@ -63,62 +50,178 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
         management::Canister::accept_cycles()
     }
 
-    /// Upgrades canisters controller by the factory and returns a list of outdated canisters
-    /// (in case an upgrade error occurs).
-    fn upgrade<'a>(
-        &'a mut self,
-        canister_bytecode: Option<WasmModule>,
-    ) -> AsyncReturn<Result<Vec<Principal>, FactoryError>> {
-        // TODO: At the moment we do not do any security checks for this method, for even if there's
-        // nothing to upgrade, it will just check all ic-helpers and do nothing else.
-        // Later, we should add here (and in create_canister methods) a cycle check,
-        // to make the caller to pay for the execution of this method.
-
+    fn check_all_states<T: CandidType + Versioned>(
+        &self,
+    ) -> AsyncReturn<HashMap<Principal, TypeCheckResult>> {
         Box::pin(async move {
-            let wasm = canister_bytecode.ok_or(FactoryError::CanisterWasmNotSet)?;
-            let canisters = self.factory_state().borrow_mut().factory.canisters.clone();
-            let curr_version = self.factory_state().borrow().factory.checksum.version;
-            let mut outdated_canisters = vec![];
+            let canisters = self.factory_state().borrow().canister_list();
+            let mut results = HashMap::default();
 
-            for (key, canister) in canisters
-                .into_iter()
-                .filter(|(_, c)| c.version() == curr_version)
+            for canister in canisters {
+                match virtual_canister_call!(canister, "state_check", (), CandidHeader).await {
+                    Ok(canister_header) => {
+                        results.insert(canister, validate_header::<T>(&canister_header))
+                    }
+                    Err(e) => results.insert(
+                        canister,
+                        TypeCheckResult::Error {
+                            remote_version: 0,
+                            current_version: T::version(),
+                            error_message: format!(
+                                "Failed to query canister state header: {}",
+                                e.1
+                            ),
+                        },
+                    ),
+                };
+            }
+
+            results
+        })
+    }
+
+    fn set_canister_code<T: CandidType + Versioned>(
+        &self,
+        wasm: Vec<u8>,
+        state_header: CandidHeader,
+    ) -> Result<u32, FactoryError> {
+        let validate_res = validate_header::<T>(&state_header);
+        if validate_res.is_err() {
+            return Err(FactoryError::StateCheckFailed(HashMap::from([(
+                self.principal(),
+                validate_res,
+            )])));
+        }
+
+        self.factory_state()
+            .borrow_mut()
+            .authorize_owner()?
+            .set_canister_wasm(wasm, state_header)
+    }
+
+    fn create_canister<'a, T: ArgumentEncoder + 'a>(
+        &'a self,
+        init_args: T,
+        controller: Option<Principal>,
+    ) -> AsyncReturn<'a, Result<Principal, FactoryError>> {
+        Box::pin(async move {
+            let state_lock = self.factory_state().borrow_mut().lock()?;
+
+            let caller = ic_canister::ic_kit::ic::caller();
+            let actor = self
+                .factory_state()
+                .borrow()
+                .consume_provided_cycles_or_icp(caller);
+            let cycles = actor.await?;
+
+            let actor = self.factory_state().borrow().create_canister(
+                init_args,
+                cycles,
+                &state_lock,
+                controller,
+            )?;
+
+            let principal = actor
+                .await
+                .map_err(|e| FactoryError::CanisterCreateFailed(e.1))?;
+
+            self.factory_state()
+                .borrow_mut()
+                .register_created(principal, &state_lock)
+                .expect("correct state lock");
+
+            Ok(principal)
+        })
+    }
+
+    fn upgrade<T: CandidType + Versioned>(
+        &mut self,
+    ) -> AsyncReturn<Result<HashMap<Principal, UpgradeResult>, FactoryError>> {
+        Box::pin(async move {
+            let state_rc = self.factory_state();
+            let state_lock = state_rc.borrow_mut().lock()?;
+
+            let caller = ic_canister::ic_kit::ic::caller();
+
+            let state_checks = self.check_all_states::<T>().await;
+            if state_checks
+                .iter()
+                .any(|(_, res)| matches!(res, TypeCheckResult::Error { .. }))
             {
-                let upgrader = self
-                    .factory_state()
+                return Err(FactoryError::StateCheckFailed(state_checks));
+            }
+
+            let module_hash = state_rc
+                .borrow()
+                .module()
+                .expect("state checks passed, it means the module is there")
+                .hash()
+                .clone();
+            let mut results = HashMap::new();
+            for (canister, _) in state_checks {
+                if state_rc.borrow().canisters()[&canister] == module_hash {
+                    results.insert(canister, UpgradeResult::Noop);
+                    continue;
+                }
+
+                // Set future to local variable to drop the state before the async call
+                let upgrader = state_rc
                     .borrow_mut()
-                    .factory
-                    .upgrade(&canister, wasm.clone());
-                if let Ok(upgraded) = upgrader.await {
-                    self.factory_state()
-                        .borrow_mut()
-                        .factory
-                        .register_upgraded(&key, upgraded)
-                } else {
-                    outdated_canisters.push(canister.identity())
+                    .authorize_owner_int(caller)?
+                    .upgrade(canister, &state_lock)
+                    .expect("module is set checked by state checks");
+
+                match upgrader.await {
+                    Ok(_) => {
+                        results.insert(canister, UpgradeResult::Upgraded);
+                    }
+                    Err(e) => {
+                        results.insert(canister, UpgradeResult::Error(e.1));
+                    }
                 }
             }
 
-            Ok(outdated_canisters)
+            {
+                let mut state = state_rc.borrow_mut();
+                let mut state = state.authorize_owner_int(caller)?;
+                for (canister, upgrade_result) in results.iter() {
+                    if matches!(upgrade_result, UpgradeResult::Upgraded) {
+                        state
+                            .register_upgraded(*canister, &state_lock)
+                            .expect("correct lock");
+                    }
+                }
+            }
+
+            Ok(results)
         })
+    }
+
+    #[update(trait = true)]
+    fn reset_update_lock(&self) -> Result<(), FactoryError> {
+        self.factory_state()
+            .borrow_mut()
+            .authorize_owner()?
+            .release_update_lock();
+        Ok(())
     }
 
     /// Returns the current version of canister.
     #[query(trait = true)]
-    fn version(&self) -> &'static str {
-        env!("CARGO_PKG_VERSION")
+    fn version(&self) -> Result<u32, FactoryError> {
+        Ok(self.factory_state().borrow().module()?.version())
     }
 
     /// Returns the number of canisters created by the factory.
     #[query(trait = true)]
     fn length(&self) -> usize {
-        self.factory_state().borrow().factory.canisters.len()
+        self.factory_state().borrow().canister_count()
     }
 
     /// Returns a vector of all canisters created by the factory.
     #[query(trait = true)]
     fn get_all(&self) -> Vec<Principal> {
-        self.factory_state().borrow().factory.all()
+        self.factory_state().borrow().canister_list()
     }
 
     /// Returns the ICP fee amount for canister creation.
@@ -131,7 +234,10 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     /// by the factory controller.
     #[update(trait = true)]
     fn set_icp_fee(&self, e8s: u64) -> Result<(), FactoryError> {
-        self.factory_state().borrow_mut().set_icp_fee(e8s)
+        self.factory_state()
+            .borrow_mut()
+            .authorize_owner()?
+            .set_icp_fee(e8s)
     }
 
     /// Returns the principal that will receive the ICP fees.
@@ -143,8 +249,11 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     /// Sets the principal that will receive the ICP fees. This method can only be called
     /// by the factory controller.
     #[update(trait = true)]
-    fn set_icp_to(&self, to: Principal) -> ::std::result::Result<(), FactoryError> {
-        self.factory_state().borrow_mut().set_icp_to(to)
+    fn set_icp_to(&self, to: Principal) -> Result<(), FactoryError> {
+        self.factory_state()
+            .borrow_mut()
+            .authorize_owner()?
+            .set_fee_to(to)
     }
 
     /// Returns the ICPs transferred to the factory by the caller. This method returns all
@@ -186,7 +295,10 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     /// Sets the factory controller principal.
     #[update(trait = true)]
     fn set_controller(&self, controller: Principal) -> Result<(), FactoryError> {
-        self.factory_state().borrow_mut().set_controller(controller)
+        self.factory_state()
+            .borrow_mut()
+            .authorize_owner()?
+            .set_controller(controller)
     }
 
     /// Returns the factory controller principal.
@@ -216,6 +328,32 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     fn get_idl() -> ic_canister::Idl {
         ic_canister::generate_idl!()
     }
+
+    fn drop_canister(&self, canister_id: Principal) -> AsyncReturn<Result<(), FactoryError>> {
+        Box::pin(async move {
+            let caller = ic_canister::ic_kit::ic::caller();
+            let state_lock = self.factory_state().borrow_mut().lock()?;
+            let actor = self
+                .factory_state()
+                .borrow_mut()
+                .authorize_owner_int(caller)?
+                .drop_canister(canister_id, &state_lock);
+
+            actor.await?;
+
+            self.factory_state()
+                .borrow_mut()
+                .authorize_owner_int(caller)?
+                .register_dropped(canister_id, &state_lock)
+        })
+    }
+}
+
+#[derive(Debug, CandidType)]
+pub enum UpgradeResult {
+    Noop,
+    Upgraded,
+    Error(String),
 }
 
 generate_exports!(FactoryCanister);

--- a/ic-factory/src/api.rs
+++ b/ic-factory/src/api.rs
@@ -134,7 +134,7 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
         })
     }
 
-    fn upgrade<T: CandidType + Versioned>(
+    fn upgrade_canister<T: CandidType + Versioned>(
         &mut self,
     ) -> AsyncReturn<Result<HashMap<Principal, UpgradeResult>, FactoryError>> {
         Box::pin(async move {

--- a/ic-factory/src/core.rs
+++ b/ic-factory/src/core.rs
@@ -1,124 +1,37 @@
 use crate::error::FactoryError;
-use crate::types::{Canister, Checksum, Version};
 use candid::utils::ArgumentEncoder;
-use candid::{CandidType, Principal};
+use candid::Principal;
 use ic_cdk::api::call::CallResult;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::future::Future;
+use ic_helpers::management::{Canister as ManagementCanister, CanisterSettings, InstallCodeMode};
 
-/// Represents a state that manages ic-helpers.
-#[derive(CandidType, Debug, Clone, Serialize, Deserialize, Default)]
-pub struct Factory {
-    pub canisters: HashMap<Principal, Canister>,
-    pub checksum: Checksum,
-}
-
-impl Factory {
-    /// Creates a new instance of `Factory`.
-    pub fn new(wasm_module: &[u8]) -> Self {
-        Self {
-            canisters: HashMap::new(),
-            checksum: wasm_module.into(),
-        }
-    }
-
-    /// This method should be called after restoring from stable memory.
-    pub fn restore(&mut self, wasm_module: &[u8]) {
-        self.checksum.upgrade(wasm_module.into());
-    }
-
-    /// Returns a canister that has been created by the factory.
-    pub fn get(&self, key: &Principal) -> Option<Principal> {
-        self.canisters.get(key).map(|canister| canister.identity())
-    }
-
-    /// Returns the number of ic-helpers cretaed by the factory.
-    pub fn len(&self) -> usize {
-        self.canisters.len()
-    }
-
-    /// Returns true if no canister is created yet.
-    pub fn is_empty(&self) -> bool {
-        self.canisters.is_empty()
-    }
-
-    /// Returns a vector of all ic-helpers created by the factory.
-    pub fn all(&self) -> Vec<Principal> {
-        self.canisters
-            .values()
-            .map(|canister| canister.identity())
-            .collect()
-    }
-
-    /// Creates a pair with cycles in it to make it workable.
-    ///
-    /// The amount of cycles that will be available in the created canister is `cycles - FEE`, where
-    /// `FEE` is a constant value needed to cover the factory expenses. Current implementation has
-    /// `FEE == 10^11 + 10^6`.
-    pub fn create_with_cycles<A: ArgumentEncoder>(
-        &self,
-        wasm_module: &[u8],
-        arg: A,
-        cycles: u64,
-    ) -> impl Future<Output = CallResult<Canister>> {
-        Canister::create(self.checksum.version, wasm_module.into(), arg, cycles)
-    }
-
-    /// Stops and deletes the canister. After this actor is awaited on, [Factory::forget] method must be used
-    /// to remove the canister from the list of created canisters.
-    pub fn drop(&self, canister: Principal) -> impl Future<Output = Result<(), FactoryError>> {
-        drop_canister(canister)
-    }
-
-    /// Adds a new canister to the canister registry. If a canister with the given key is already
-    /// registered, it will be replaced with the new one.
-    pub fn register(&mut self, key: Principal, canister: Canister) {
-        self.canisters.insert(key, canister);
-    }
-
-    /// Removes the canister from the registry. Return error if the canister with the given key is
-    /// not registered.
-    pub fn forget(&mut self, key: &Principal) -> Result<(), FactoryError> {
-        self.canisters
-            .remove(key)
-            .ok_or(FactoryError::NotFound)
-            .map(|_| ())
-    }
-
-    /// Returns a future that upgrades a canister to the given bytecode. After the future is
-    /// done executing, `register_upgraded` method shall be called to add the resulting canister to the
-    /// registry.
-    ///
-    /// Please, note that the state should not be borrowed when this future is awaited on, to prevent
-    /// memory access conflict in case of concurrent requests.
-    pub fn upgrade(
-        &self,
-        canister: &Canister,
-        wasm_module: Vec<u8>,
-    ) -> impl Future<Output = CallResult<Canister>> {
-        upgrade_canister(self.checksum.version, canister.clone(), wasm_module)
-    }
-
-    /// Updates the canister to the newer version. If no canister with the given key is registered,
-    /// nothing is done.
-    pub fn register_upgraded(&mut self, key: &Principal, canister: Canister) {
-        if let Some(val) = self.canisters.get_mut(key) {
-            *val = canister;
-        }
-    }
-}
-
-async fn upgrade_canister(
-    version: Version,
-    mut canister: Canister,
+pub async fn create_canister<T: ArgumentEncoder>(
     wasm_module: Vec<u8>,
-) -> CallResult<Canister> {
-    canister.upgrade(version, wasm_module).await?;
-    Ok(canister)
+    init_args: T,
+    cycles: u64,
+    controllers: Option<Vec<Principal>>,
+) -> CallResult<Principal> {
+    let settings = CanisterSettings {
+        controllers,
+        compute_allocation: None,
+        memory_allocation: None,
+        freezing_threshold: None,
+    };
+
+    let canister = ManagementCanister::create(Some(settings), cycles).await?;
+    canister
+        .install_code(InstallCodeMode::Install, wasm_module, init_args)
+        .await?;
+
+    Ok(canister.into())
 }
 
-async fn drop_canister(canister: Principal) -> Result<(), FactoryError> {
+pub async fn upgrade_canister(canister_id: Principal, wasm_module: Vec<u8>) -> CallResult<()> {
+    ManagementCanister::from(canister_id)
+        .install_code(InstallCodeMode::Upgrade, wasm_module, ())
+        .await
+}
+
+pub async fn drop_canister(canister: Principal) -> Result<(), FactoryError> {
     let canister = ic_helpers::management::Canister::from(canister);
     canister
         .stop()

--- a/ic-factory/src/core.rs
+++ b/ic-factory/src/core.rs
@@ -12,9 +12,7 @@ pub async fn create_canister<T: ArgumentEncoder>(
 ) -> CallResult<Principal> {
     let settings = CanisterSettings {
         controllers,
-        compute_allocation: None,
-        memory_allocation: None,
-        freezing_threshold: None,
+        ..Default::default()
     };
 
     let canister = ManagementCanister::create(Some(settings), cycles).await?;

--- a/ic-factory/src/error.rs
+++ b/ic-factory/src/error.rs
@@ -1,7 +1,7 @@
-use ic_cdk::export::candid::{CandidType, Deserialize};
+use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
 use thiserror::Error;
 
-#[derive(Debug, Error, CandidType, Deserialize, PartialEq)]
+#[derive(Debug, Error, CandidType, Deserialize)]
 pub enum FactoryError {
     #[error("request to the ledger failed: {0}")]
     LedgerError(String),
@@ -26,4 +26,15 @@ pub enum FactoryError {
 
     #[error("factory is not initialized properly: canister wasm not set")]
     CanisterWasmNotSet,
+
+    #[error("upgrade failed becuase one or more canisters have incompatable type")]
+    StateCheckFailed(
+        std::collections::HashMap<Principal, ic_helpers::candid_header::TypeCheckResult>,
+    ),
+
+    #[error("factory state is locked due to another async operation running")]
+    StateLocked,
+
+    #[error("failed to create canister: {0}")]
+    CanisterCreateFailed(String),
 }

--- a/ic-factory/src/error.rs
+++ b/ic-factory/src/error.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
+use ic_helpers::candid_header::TypeCheckResult;
 use thiserror::Error;
 
 #[derive(Debug, Error, CandidType, Deserialize)]
@@ -28,9 +31,7 @@ pub enum FactoryError {
     CanisterWasmNotSet,
 
     #[error("upgrade failed becuase one or more canisters have incompatable type")]
-    StateCheckFailed(
-        std::collections::HashMap<Principal, ic_helpers::candid_header::TypeCheckResult>,
-    ),
+    StateCheckFailed(HashMap<Principal, TypeCheckResult>),
 
     #[error("factory state is locked due to another async operation running")]
     StateLocked,

--- a/ic-factory/src/lib.rs
+++ b/ic-factory/src/lib.rs
@@ -4,6 +4,7 @@ mod state;
 
 pub mod error;
 pub mod types;
+pub mod update_lock;
 
 pub use self::core::*;
 pub use self::state::*;

--- a/ic-factory/src/state.rs
+++ b/ic-factory/src/state.rs
@@ -10,7 +10,6 @@ use ic_storage::stable::Versioned;
 use ic_storage::IcStorage;
 use std::collections::HashMap;
 use std::future::Future;
-use std::marker::PhantomData;
 use v1::{Factory, FactoryStateV1};
 
 pub mod v1;

--- a/ic-factory/src/state.rs
+++ b/ic-factory/src/state.rs
@@ -1,14 +1,407 @@
+use crate::core::{create_canister, drop_canister, upgrade_canister};
 use crate::error::FactoryError;
-use crate::Factory;
+use crate::update_lock::UpdateLock;
+use ic_cdk::api::call::CallResult;
+use ic_cdk::export::candid::utils::ArgumentEncoder;
 use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
-
+use ic_helpers::candid_header::CandidHeader;
 use ic_helpers::ledger::{LedgerPrincipalExt, PrincipalId, DEFAULT_TRANSFER_FEE};
 use ic_storage::stable::Versioned;
 use ic_storage::IcStorage;
+use std::collections::HashMap;
 use std::future::Future;
-use std::pin::Pin;
+use std::marker::PhantomData;
+use v1::{Factory, FactoryStateV1};
+
+pub mod v1;
 
 pub const DEFAULT_ICP_FEE: u64 = 10u64.pow(8);
+
+type CanisterHash = Vec<u8>;
+
+#[derive(Debug, Default, CandidType, Deserialize, IcStorage)]
+pub struct FactoryState {
+    configuration: FactoryConfiguration,
+    module: Option<CanisterModule>,
+    canisters: HashMap<Principal, CanisterHash>,
+    update_lock: UpdateLock,
+}
+
+#[derive(Debug, CandidType, Deserialize)]
+pub struct CanisterModule {
+    wasm: Vec<u8>,
+    hash: CanisterHash,
+    version: u32,
+    state_header: CandidHeader,
+}
+
+impl CanisterModule {
+    pub fn hash(&self) -> &Vec<u8> {
+        &self.hash
+    }
+
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+impl Versioned for FactoryState {
+    type Previous = FactoryStateV1;
+
+    fn upgrade(prev: Self::Previous) -> Self {
+        let FactoryStateV1 {
+            configuration,
+            factory,
+        } = prev;
+        let Factory {
+            canisters,
+            checksum,
+        } = factory;
+
+        let hash = checksum.hash;
+
+        Self {
+            configuration,
+
+            // After the upgrade the canister wasm module would have to be uploaded again to
+            // provide the state header.
+            module: None,
+
+            // We assume for now that the canisters were not modified by external controllers, as
+            // we didn't keep track of each canister has before.
+            canisters: canisters
+                .into_iter()
+                .map(|(principal, _)| (principal, hash.clone()))
+                .collect(),
+
+            update_lock: UpdateLock::default(),
+        }
+    }
+}
+
+impl FactoryState {
+    pub fn new(configuration: FactoryConfiguration) -> Self {
+        Self {
+            configuration,
+            ..Default::default()
+        }
+    }
+
+    /// Checks if the request caller is the factory conctroller (owner).
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactoryError::AccessDenied` if the caller is not the factory controller.
+    pub fn authorize_owner(&mut self) -> Result<Authorized<Owner>, FactoryError> {
+        let caller = ic_canister::ic_kit::ic::caller();
+        self.authorize_owner_int(caller)
+    }
+
+    // In some cases we need to call owner-only operations after `await` point, when `ic::caller()`
+    // cannot be called (due to IC limitation). In this case we use this method with the caller,
+    // retrieved before the `await` point. To prevent incorrect usage of this method it is
+    // `pub(crate)` only.
+    pub(crate) fn authorize_owner_int<'a>(
+        &'a mut self,
+        caller: Principal,
+    ) -> Result<Authorized<'a, Owner>, FactoryError> {
+        if caller == self.configuration.controller {
+            Ok(Authorized::<'a, Owner> {
+                factory: self,
+                phantom: PhantomData::default(),
+            })
+        } else {
+            Err(FactoryError::AccessDenied)
+        }
+    }
+
+    /// Returns the controller (owner) of the factory.
+    pub fn controller(&self) -> Principal {
+        self.configuration.controller
+    }
+
+    /// Returns the ICP ledger principal that the factory work with.
+    pub fn ledger_principal(&self) -> Principal {
+        self.configuration.ledger_principal
+    }
+
+    /// Returns the icp_fee configuration.
+    pub fn icp_fee(&self) -> u64 {
+        self.configuration.icp_fee
+    }
+
+    /// Returns the icp_to configuration.
+    pub fn icp_to(&self) -> Principal {
+        self.configuration.icp_to
+    }
+
+    /// Creates a new canister with the wasm code stored in the factory state.
+    ///
+    /// Arguments:
+    /// * `init_args` - arguments to send to the canister `init` method.
+    /// * `cycles` - number of cycles to create the canister with. The factory must have enough
+    ///   cycles as they are reduced from the factory balance.
+    /// * `lock` - state update lock. This is used to ensure that the the factory state is editable
+    ///   while the new canister is been created.
+    /// * `controller` - additional controller principal to set for the created canister. The
+    ///   factory always sets itself as a controller, but if this option is not `None`, the given
+    ///   principal will be a second controller of the canister.
+    ///
+    /// This method returns a future that does not require the `FactoryState` to be borrowed when
+    /// it is awaited. This design allows us drop the state borrow before making the async call to
+    /// prevent possible `BorrowError`s and braking the state. This also means that this method
+    /// cannot write the resulting canister principal into the list of the canisters, so the
+    /// calling function must call [`register_created`] method after successful canister creation.
+    ///
+    /// To prevent incorrect usage of this method it is `pub(crate)`. Dependant crates should use
+    /// [`FactoryCanister::create_canister`] method instead, that takes care of all this.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactoryError::CanisterWasmNotSet` if the canister code is not set.
+    ///
+    /// # Panics
+    ///
+    /// If the given lock is not the factory's lock. This should never happen if the factory code
+    /// is written correctly.
+    pub(crate) fn create_canister<A: ArgumentEncoder>(
+        &self,
+        init_args: A,
+        cycles: u64,
+        lock: &UpdateLock,
+        controller: Option<Principal>,
+    ) -> Result<impl Future<Output = CallResult<Principal>>, FactoryError> {
+        self.check_lock(lock);
+
+        let wasm = self.module()?.wasm.clone();
+        Ok(create_canister(
+            wasm,
+            init_args,
+            cycles,
+            controller.map(|p| vec![ic_canister::ic_kit::ic::id(), p]),
+        ))
+    }
+
+    /// Writes a new canister to the list of the factory canisters. It assumes that the canister
+    /// was created with the wasm that is currently in the `FactoryState::module` field.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FactoryError::CanisterWasmNotSet` if the canister code is not set.
+    ///
+    /// # Panics
+    ///
+    /// If the given lock is not the factory's lock. This should never happen if the factory code
+    /// is written correctly.
+    pub(crate) fn register_created(
+        &mut self,
+        canister_id: Principal,
+        lock: &UpdateLock,
+    ) -> Result<(), FactoryError> {
+        self.check_lock(lock);
+        self.canisters
+            .insert(canister_id, self.module()?.hash.clone());
+        Ok(())
+    }
+
+    /// Returns information about the wasm code the factory uses to create canisters.
+    pub fn module(&self) -> Result<&CanisterModule, FactoryError> {
+        self.module.as_ref().ok_or(FactoryError::CanisterWasmNotSet)
+    }
+
+    /// Number of canisters the factory keeps track of.
+    pub fn canister_count(&self) -> usize {
+        self.canisters.len()
+    }
+
+    /// List of canisters the factory keeps track of.
+    pub fn canister_list(&self) -> Vec<Principal> {
+        self.canisters.keys().copied().collect()
+    }
+
+    /// HashMap of canisters the factory keeps track of with their code hashes.
+    pub fn canisters(&self) -> &HashMap<Principal, CanisterHash> {
+        &self.canisters
+    }
+
+    /// Locks the `FactoryState`, prohibiting any update operations on it until the returned lock
+    /// object is dropped. See [`UpdateLock`] documentation for more details about how and why this works.
+    pub fn lock(&mut self) -> Result<UpdateLock, FactoryError> {
+        self.update_lock.lock()
+    }
+
+    fn check_update_allowed(&self) -> Result<(), FactoryError> {
+        match self.update_lock.is_locked() {
+            true => Err(FactoryError::StateLocked),
+            false => Ok(()),
+        }
+    }
+
+    // If the caller can provide a lock to this method, it means that the state is locked, as there
+    // is no way to get the lock object except by calling the [`lock`] method. So the purpose of
+    // this check is to guard against creating a completely different `UpdateLock` object and
+    // giving it to a facotry method. In such case we simply panick to make it clear that the code
+    // that did such a thing is broken and must be fixed.
+    fn check_lock(&self, lock: &UpdateLock) {
+        assert_eq!(*lock, self.update_lock, "invalid update lock usage")
+    }
+
+    /// Consumes the fee for canister creation in the form of cycles (if provided by the call) or
+    /// ICP in other case. Returns an error in case nor cycles nor ICP are provided and the caller
+    /// is not the factory controller.
+    pub fn consume_provided_cycles_or_icp(
+        &self,
+        caller: Principal,
+    ) -> impl Future<Output = Result<u64, FactoryError>> {
+        let ledger = self.ledger_principal();
+        let icp_to = self.icp_to();
+        let icp_fee = self.icp_fee();
+        let controller = self.controller();
+
+        consume_provided_cycles_or_icp(caller, ledger, icp_to, icp_fee, controller)
+    }
+}
+
+/// Abstraction to provided compile time checks for factory method access.
+pub struct Authorized<'a, T> {
+    factory: &'a mut FactoryState,
+    phantom: PhantomData<T>,
+}
+
+/// The operation caller is the factory controller (owner).
+pub struct Owner;
+
+impl<'a> Authorized<'a, Owner> {
+    /// Sets the new version of the wasm code that is used to create new canisters. The
+    /// `state_header` argument must provide the current canister state descrition.
+    pub fn set_canister_wasm(
+        &mut self,
+        wasm: Vec<u8>,
+        state_header: CandidHeader,
+    ) -> Result<u32, FactoryError> {
+        self.factory.check_update_allowed()?;
+        let module_version = self.factory.module.as_ref().map(|m| m.version).unwrap_or(0);
+        let hash = get_canister_hash(&wasm);
+
+        let module = CanisterModule {
+            wasm,
+            hash,
+            version: module_version,
+            state_header,
+        };
+
+        self.factory.module = Some(module);
+        Ok(module_version)
+    }
+
+    /// Update the factory controller.
+    pub fn set_controller(&mut self, controller: Principal) -> Result<(), FactoryError> {
+        self.factory.check_update_allowed()?;
+        self.factory.configuration.controller = controller;
+
+        Ok(())
+    }
+
+    /// Update the ledger principal.
+    pub fn set_ledger_principal(
+        &mut self,
+        ledger_principal: Principal,
+    ) -> Result<(), FactoryError> {
+        self.factory.check_update_allowed()?;
+        self.factory.configuration.ledger_principal = ledger_principal;
+
+        Ok(())
+    }
+
+    /// UYpdate the icp_fee configuration.
+    pub fn set_icp_fee(&mut self, fee: u64) -> Result<(), FactoryError> {
+        self.factory.check_update_allowed()?;
+        self.factory.configuration.icp_fee = fee;
+
+        Ok(())
+    }
+
+    /// Update the icp_to configuration.
+    pub fn set_fee_to(&mut self, fee_to: Principal) -> Result<(), FactoryError> {
+        self.factory.check_update_allowed()?;
+        self.factory.configuration.icp_to = fee_to;
+
+        Ok(())
+    }
+
+    /// Upgrade the code of the canister to the current module wasm code.
+    ///
+    /// This method works in a similar way to [`create_canister`], see its documentation for the
+    /// details. [`register_upgraded`] method must be called after successfully awaiting on the
+    /// returned future.
+    pub(crate) fn upgrade(
+        &self,
+        canister_id: Principal,
+        lock: &UpdateLock,
+    ) -> Result<impl Future<Output = CallResult<()>>, FactoryError> {
+        self.factory.check_lock(lock);
+
+        Ok(upgrade_canister(
+            canister_id,
+            self.factory.module()?.wasm.clone(),
+        ))
+    }
+
+    /// Updates the stored canister hash. Call this method after awaiting on [`upgrade`].
+    pub(crate) fn register_upgraded(
+        &mut self,
+        canister_id: Principal,
+        lock: &UpdateLock,
+    ) -> Result<(), FactoryError> {
+        self.factory.check_lock(lock);
+        self.factory
+            .canisters
+            .insert(canister_id, self.factory.module()?.hash.clone());
+
+        Ok(())
+    }
+
+    /// Resets the factory state update lock to unlocked state. This method can be only called by
+    /// the factory controller and is supposed to be used only in case the state was broken by some
+    /// disaster.
+    pub(crate) fn release_update_lock(&mut self) {
+        self.factory.update_lock.unlock()
+    }
+
+    /// Drops the canister.
+    ///
+    /// This method works in a similar way to [`create_canister`], see its documentation for the
+    /// details. [`register_dropped`] must be called after awaiting on the reeturned fututre.
+    pub(crate) fn drop_canister(
+        &mut self,
+        canister_id: Principal,
+        lock: &UpdateLock,
+    ) -> impl Future<Output = Result<(), FactoryError>> {
+        self.factory.check_lock(lock);
+        drop_canister(canister_id)
+    }
+
+    /// Removes the canister from the list of tracked canisters.
+    pub(crate) fn register_dropped(
+        &mut self,
+        canister_id: Principal,
+        lock: &UpdateLock,
+    ) -> Result<(), FactoryError> {
+        self.factory.check_lock(lock);
+        match self.factory.canisters.remove(&canister_id) {
+            Some(_) => Ok(()),
+            None => Err(FactoryError::NotFound),
+        }
+    }
+}
+
+fn get_canister_hash(wasm: &[u8]) -> CanisterHash {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(wasm);
+    hasher.finalize().as_slice().into()
+}
 
 #[derive(Debug, CandidType, Deserialize)]
 pub struct FactoryConfiguration {
@@ -42,98 +435,6 @@ impl Default for FactoryConfiguration {
             icp_to: Principal::anonymous(),
             controller: Principal::anonymous(),
         }
-    }
-}
-
-#[derive(CandidType, Deserialize, IcStorage)]
-pub struct FactoryState {
-    pub configuration: FactoryConfiguration,
-    pub factory: Factory,
-}
-
-impl Versioned for FactoryState {
-    type Previous = ();
-
-    fn upgrade((): ()) -> Self {
-        Self::default()
-    }
-}
-
-impl Default for FactoryState {
-    fn default() -> Self {
-        Self {
-            configuration: FactoryConfiguration::default(),
-            factory: Factory::new(&[]),
-        }
-    }
-}
-
-/// This trait must be implemented by a factory state to make using of `init_factory_api` macro
-/// possible.
-impl FactoryState {
-    pub fn ledger_principal(&self) -> Principal {
-        self.configuration.ledger_principal
-    }
-
-    pub fn controller(&self) -> Principal {
-        self.configuration.controller
-    }
-
-    pub fn set_controller(&mut self, controller: Principal) -> Result<(), FactoryError> {
-        self.check_controller_access()?;
-        self.configuration.controller = controller;
-
-        Ok(())
-    }
-
-    pub fn icp_fee(&self) -> u64 {
-        self.configuration.icp_fee
-    }
-
-    pub fn set_icp_fee(&mut self, fee: u64) -> Result<(), FactoryError> {
-        self.check_controller_access()?;
-        self.configuration.icp_fee = fee;
-
-        Ok(())
-    }
-
-    pub fn icp_to(&self) -> Principal {
-        self.configuration.icp_to
-    }
-
-    pub fn set_icp_to(&mut self, to: Principal) -> Result<(), FactoryError> {
-        self.check_controller_access()?;
-        self.configuration.icp_to = to;
-
-        Ok(())
-    }
-
-    pub fn consume_provided_cycles_or_icp(
-        &self,
-        caller: Principal,
-        // ) -> Pin<Box<dyn Future<Output = Result<u64, FactoryError>> + Send>> {
-    ) -> Pin<Box<dyn Future<Output = Result<u64, FactoryError>>>> {
-        Box::pin(consume_provided_cycles_or_icp(
-            caller,
-            self.ledger_principal(),
-            self.icp_to(),
-            self.icp_fee(),
-            self.controller(),
-        ))
-    }
-
-    pub fn check_controller_access(&self) -> Result<(), FactoryError> {
-        let caller = ic_kit::ic::caller();
-        if caller == self.controller() {
-            Ok(())
-        } else {
-            Err(FactoryError::AccessDenied)
-        }
-    }
-
-    pub fn forget_canister(&mut self, canister: &Principal) -> Result<(), FactoryError> {
-        self.check_controller_access()?;
-        self.factory.forget(canister)
     }
 }
 

--- a/ic-factory/src/state.rs
+++ b/ic-factory/src/state.rs
@@ -103,7 +103,7 @@ impl FactoryState {
     pub fn authorize_owner(&mut self) -> Result<Authorized<Owner>, FactoryError> {
         let caller = ic_canister::ic_kit::ic::caller();
         if caller == self.configuration.controller {
-            Ok(Authorized::<Owner> {
+            Ok(Authorized::<Owner<'_>> {
                 auth: Owner { factory: self },
             })
         } else {

--- a/ic-factory/src/state/v1.rs
+++ b/ic-factory/src/state/v1.rs
@@ -1,0 +1,26 @@
+use super::FactoryConfiguration;
+use crate::types::{Canister, Checksum};
+use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
+use ic_storage::stable::Versioned;
+use ic_storage::IcStorage;
+use std::collections::HashMap;
+
+#[derive(CandidType, Deserialize, IcStorage, Default)]
+pub struct FactoryStateV1 {
+    pub configuration: FactoryConfiguration,
+    pub factory: Factory,
+}
+
+impl Versioned for FactoryStateV1 {
+    type Previous = ();
+
+    fn upgrade((): ()) -> Self {
+        Self::default()
+    }
+}
+
+#[derive(CandidType, Deserialize, Default)]
+pub struct Factory {
+    pub canisters: HashMap<Principal, Canister>,
+    pub checksum: Checksum,
+}

--- a/ic-factory/src/types/checksum.rs
+++ b/ic-factory/src/types/checksum.rs
@@ -9,7 +9,7 @@ pub type Version = usize;
 #[derive(CandidType, Debug, Clone, Serialize, Deserialize, Default, Eq)]
 pub struct Checksum {
     pub version: Version,
-    hash: Vec<u8>,
+    pub hash: Vec<u8>,
 }
 
 impl Checksum {

--- a/ic-factory/src/update_lock.rs
+++ b/ic-factory/src/update_lock.rs
@@ -3,7 +3,7 @@ use ic_cdk::export::candid::{CandidType, Deserialize};
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// A guard to prevent factory state changes whily an async operation is in process.
+/// A guard to prevent factory state changes while an async operation is in process.
 ///
 /// The guarded structure stores the original lock object as one of its fields. To set the lock
 /// [`lock`] method is called, returning a clone of this object in the locked state. Any consequent
@@ -11,7 +11,7 @@ use std::rc::Rc;
 ///
 /// We need to use this lock type instead of relying on `RefCell` borrowed `Ref` as a lock because
 /// it is possible in IC environment to get the canister to a state when the `Ref` object is lost
-/// without dropping it, which makes the state locked forever. The `UpdateLock` allowes to fix such
+/// without dropping it, which makes the state locked forever. The `UpdateLock` allows to fix such
 /// state by calling the [`unlock`] method.
 #[derive(Debug, Default)]
 pub struct UpdateLock {
@@ -25,7 +25,7 @@ impl UpdateLock {
     /// # Errors
     ///
     /// If the lock is already in the locked state, calling `lock` will return
-    /// `Err(FactoryError::StateLocked)` error;
+    /// `Err(FactoryError::StateLocked)` error.
     pub fn lock(&self) -> Result<Self, FactoryError> {
         if *self.is_locked.borrow() {
             return Err(FactoryError::StateLocked);

--- a/ic-factory/src/update_lock.rs
+++ b/ic-factory/src/update_lock.rs
@@ -1,0 +1,137 @@
+use crate::error::FactoryError;
+use ic_cdk::export::candid::{CandidType, Deserialize};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// A guard to prevent factory state changes whily an async operation is in process.
+///
+/// The guarded structure stores the original lock object as one of its fields. To set the lock
+/// [`lock`] method is called, returning a clone of this object in the locked state. Any consequent
+/// calls to the `lock` method will return an error until the first lock is dropped.
+///
+/// We need to use this lock type instead of relying on `RefCell` borrowed `Ref` as a lock because
+/// it is possible in IC environment to get the canister to a state when the `Ref` object is lost
+/// without dropping it, which makes the state locked forever. The `UpdateLock` allowes to fix such
+/// state by calling the [`unlock`] method.
+#[derive(Debug, Default)]
+pub struct UpdateLock {
+    is_locked: Rc<RefCell<bool>>,
+}
+
+impl UpdateLock {
+    /// Set the lock into the locked state, returning a copy of the lock. The lock will be locked
+    /// until the returned object is dropped.
+    ///
+    /// # Errors
+    ///
+    /// If the lock is already in the locked state, calling `lock` will return
+    /// `Err(FactoryError::StateLocked)` error;
+    pub fn lock(&self) -> Result<Self, FactoryError> {
+        if *self.is_locked.borrow() {
+            return Err(FactoryError::StateLocked);
+        }
+
+        self.is_locked.replace(true);
+        Ok(Self {
+            is_locked: self.is_locked.clone(),
+        })
+    }
+
+    /// Returns if the lock is locked.
+    pub fn is_locked(&self) -> bool {
+        *self.is_locked.borrow()
+    }
+
+    /// Resets the state of the lock to be unlocked.
+    ///
+    /// This method is supposed to be used only to fix a broken state, which can happen in case a
+    /// panic occurs after `await` in an async update method, while the lock is not released. That
+    /// is the reason why this method is `pub(crate)` - to limit the places where it can be used.
+    pub(crate) fn unlock(&self) {
+        self.is_locked.replace(false);
+    }
+}
+
+impl Drop for UpdateLock {
+    fn drop(&mut self) {
+        self.is_locked.replace(false);
+    }
+}
+
+impl PartialEq for UpdateLock {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.is_locked, &other.is_locked)
+    }
+}
+
+impl CandidType for UpdateLock {
+    fn _ty() -> candid::types::Type {
+        candid::types::Type::Bool
+    }
+
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: candid::types::Serializer,
+    {
+        (*self.is_locked.borrow()).idl_serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for UpdateLock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let val = bool::deserialize(deserializer)?;
+        Ok(Self {
+            is_locked: Rc::new(RefCell::new(val)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::{Decode, Encode};
+
+    #[test]
+    fn unlock_on_drop() {
+        let original = UpdateLock::default();
+        assert!(!original.is_locked());
+
+        let lock = original.lock().unwrap();
+        assert!(original.is_locked());
+        assert!(lock.is_locked());
+
+        drop(lock);
+        assert!(!original.is_locked());
+    }
+
+    #[test]
+    fn lock_serialization() {
+        let original = UpdateLock::default();
+        let lock = original.lock().unwrap();
+
+        let encoded = Encode!(&lock).unwrap();
+        let decoded = Decode!(&encoded, UpdateLock).unwrap();
+
+        assert!(decoded.is_locked(), "not locked after decoding");
+    }
+
+    #[test]
+    fn double_lock() {
+        let original = UpdateLock::default();
+        let _lock = original.lock().unwrap();
+
+        assert!(matches!(original.lock(), Err(FactoryError::StateLocked)));
+    }
+
+    #[test]
+    fn admin_unlocking() {
+        let original = UpdateLock::default();
+        let _lock = original.lock().unwrap();
+        original.unlock();
+
+        assert!(!original.is_locked());
+    }
+}

--- a/ic-helpers/Cargo.toml
+++ b/ic-helpers/Cargo.toml
@@ -35,6 +35,7 @@ auto_ops = "0.3"
 crypto-bigint = { version = "0.4", features = ["serde"] }
 num-bigint = "0.4"
 subtle = "2"
+binread = "2.2"
 
 # This dependency is not used direcly, but we must enable `custom` feature for it to compile for wasm32 target.
 [target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]


### PR DESCRIPTION
* Adds update_lock on the state to prevent state modification while
  upgrade or create processes are on the way
* Adds the state check on the canisters before their code is upgraded.
  This state check verifies that the state is not modified or if it is,
  that it uses a new version as defined by the `Versioned` trait.
* Adds the static typed check on factory operation permissions.