### PR TITLE
[CPROD-1165] do not add methods to IDL if no_api feature is used

### DIFF
--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -611,7 +611,7 @@ pub(crate) fn generate_idl() -> TokenStream {
                 let mut rets = Vec::new();
                 #(#rets)*
                 let func = Function { args, rets, modes: #modes };
-                if !cfg!(feature = "no_api") || (#name != "burn" && #name != "mint") {
+                if !cfg!(feature = "no_api") {
                     service.push((#name.to_string(), Type::Func(func)));
                 }
             }
@@ -647,6 +647,7 @@ pub(crate) fn generate_idl() -> TokenStream {
 
     TokenStream::from(res)
 }
+
 
 fn generate_arg(name: proc_macro2::TokenStream, ty: &str) -> proc_macro2::TokenStream {
     let ty = syn::parse_str::<Type>(ty).unwrap();

--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -286,8 +286,7 @@ pub(crate) fn state_getter(_attr: TokenStream, item: TokenStream) -> TokenStream
         }
     }
 
-    // Check return type of the getter 
-
+    // Check return type of the getter
     let return_type = match &input.sig.output {
         ReturnType::Default => panic!("No return type for state getter is specified"),
         ReturnType::Type(_, t) => crate::derive::get_state_type(&*t),
@@ -612,7 +611,9 @@ pub(crate) fn generate_idl() -> TokenStream {
                 let mut rets = Vec::new();
                 #(#rets)*
                 let func = Function { args, rets, modes: #modes };
-                service.push((#name.to_string(), Type::Func(func)));
+                if !cfg!(feature = "no_api") || (#name != "burn" && #name != "mint") {
+                    service.push((#name.to_string(), Type::Func(func)));
+                }
             }
         }
     });


### PR DESCRIPTION
This ticket gets rid of `mint` and `burn` features when `no_api` feature is used. We can not run the AMM pair with `no_api` feature as this will also get rid of the `mint` and `burn` methods