### PR TITLE
Fix clippy warnings

### DIFF
--- a/ic-auction/src/error.rs
+++ b/ic-auction/src/error.rs
@@ -1,7 +1,7 @@
 use ic_cdk::export::candid::{CandidType, Deserialize};
 use thiserror::Error;
 
-#[derive(Error, CandidType, Debug, Clone, Deserialize, PartialEq)]
+#[derive(Error, CandidType, Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum AuctionError {
     #[error("provided cycles in the `bid_cycles` call is less then the minimum allowed amount")]
     BiddingTooSmall,

--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -289,7 +289,7 @@ pub(crate) fn state_getter(_attr: TokenStream, item: TokenStream) -> TokenStream
     // Check return type of the getter
     let return_type = match &input.sig.output {
         ReturnType::Default => panic!("No return type for state getter is specified"),
-        ReturnType::Type(_, t) => crate::derive::get_state_type(&*t),
+        ReturnType::Type(_, t) => crate::derive::get_state_type(t),
     };
 
     let path = match return_type {
@@ -383,7 +383,7 @@ impl Parse for GenerateExportsInput {
         let trait_name = input.parse::<Ident>()?;
         let (struct_name, struct_vis) = if input.is_empty() {
             (
-                Ident::new(&format!("__{}_Ident", trait_name.to_string()), input.span()),
+                Ident::new(&format!("__{}_Ident", trait_name), input.span()),
                 Visibility::Inherited,
             )
         } else {

--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -286,8 +286,7 @@ pub(crate) fn state_getter(_attr: TokenStream, item: TokenStream) -> TokenStream
         }
     }
 
-    // Check return type of the getter 
-
+    // Check return type of the getter
     let return_type = match &input.sig.output {
         ReturnType::Default => panic!("No return type for state getter is specified"),
         ReturnType::Type(_, t) => crate::derive::get_state_type(&*t),
@@ -612,7 +611,9 @@ pub(crate) fn generate_idl() -> TokenStream {
                 let mut rets = Vec::new();
                 #(#rets)*
                 let func = Function { args, rets, modes: #modes };
-                service.push((#name.to_string(), Type::Func(func)));
+                if !cfg!(feature = "no_api") || (#name != "burn" && #name != "mint") {
+                    service.push((#name.to_string(), Type::Func(func)));
+                }
             }
         }
     });

--- a/ic-factory/src/api.rs
+++ b/ic-factory/src/api.rs
@@ -92,12 +92,11 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
             )])));
         }
 
-        let res = self
+        self
             .factory_state()
             .borrow_mut()
             .check_is_owner()?
-            .set_canister_wasm(wasm, state_header);
-        res
+            .set_canister_wasm(wasm, state_header)
     }
 
     #[allow(unused_variables)]


### PR DESCRIPTION
Merge CPROD-1165-be-do-not-add-methods-to-idl-if-no-api-feature-is-used first, these are just clippy fixes