### PR TITLE
[CPROD-1163] Update IC dependency

### DIFF
--- a/ic-auction/Cargo.toml
+++ b/ic-auction/Cargo.toml
@@ -9,7 +9,7 @@ no_api = []
 
 [dependencies]
 ic-cdk = "0.5"
-candid = "=0.7.14" # Because there is a build issue with ic_types::principal::PrincipalError 
+candid = "0.7"
 ic-kit = { git = "https://github.com/infinity-swap/ic-kit", tag = "v0.4.6" }
 serde = "1.0"
 serde_json = "1.0"

--- a/ic-auction/src/error.rs
+++ b/ic-auction/src/error.rs
@@ -1,7 +1,7 @@
 use ic_cdk::export::candid::{CandidType, Deserialize};
 use thiserror::Error;
 
-#[derive(Error, CandidType, Debug, Clone, Deserialize, PartialEq)]
+#[derive(Error, CandidType, Debug, Clone, Deserialize, PartialEq, Eq)]
 pub enum AuctionError {
     #[error("provided cycles in the `bid_cycles` call is less then the minimum allowed amount")]
     BiddingTooSmall,

--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -104,7 +104,7 @@ pub(crate) fn api_method(
 
     for arg in args {
         let (arg_type, arg_pat) = match arg {
-            FnArg::Receiver(r) => {
+            FnArg::Receiver(_) => {
                 has_self = true;
                 continue;
             }

--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -292,19 +292,20 @@ pub(crate) fn state_getter(_attr: TokenStream, item: TokenStream) -> TokenStream
 
     let segment = path.path.segments.iter().last();
 
-    if segment.is_none() {
-        return syn::Error::new(
-            input.span(),
-            format!(
-                "unexpected return type for state getter: {:#?}",
-                return_type
-            ),
-        )
-        .to_compile_error()
-        .into();
-    }
-
-    let state_type = segment.expect("already checked").ident.to_string();
+    let state_type = match segment {
+        Some(segment) => segment.ident.to_string(),
+        None => {
+            return syn::Error::new(
+                input.span(),
+                format!(
+                    "unexpected return type for state getter: {:#?}",
+                    return_type
+                ),
+            )
+            .to_compile_error()
+            .into()
+        }
+    };
 
     // Check that the body of the getter is empty
 

--- a/ic-factory/Cargo.toml
+++ b/ic-factory/Cargo.toml
@@ -9,11 +9,13 @@ agent = ["ic-agent", "garcon"]
 no_api = []
 
 [dependencies]
-ledger-canister = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
-ic-base-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
+ledger-canister = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
+ic-base-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
+cycles-minting-canister = { git="https://github.com/dfinity/ic",branch="rc--2022-09-11_18-31"}
+ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
 hex = "0.4"
 ic-cdk = "0.5"
-candid = "=0.7.14" # Because there is a build issue with ic_types::principal::PrincipalError 
+candid = "0.7"
 ic-kit = { git = "https://github.com/infinity-swap/ic-kit", tag = "v0.4.6" }
 num-traits = "0.2"
 serde = "1.0"
@@ -21,17 +23,16 @@ serde_json = "1.0"
 sha2 = "0.9"
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.2"
-ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
 thiserror = "1.0"
 ic-canister = { path = "../ic-canister/ic-canister", package = "ic-canister" }
 ic-canister-macros = { path = "../ic-canister/ic-canister-macros", package = "ic-canister-macros" }
 ic-storage = { path = "../ic-storage", package = "ic-storage" }
 ic-helpers = { path = "../ic-helpers", package = "ic-helpers" }
 leb128 = "0.2.5"
-ic-agent = { version = "0.16", optional = true }
+ic-agent = { version = "0.20", optional = true }
 garcon = { version = "0.2", optional = true}
 libsecp256k1 = { version = "0.7", optional = false}
-k256 = { version = "0.10" }
+k256 = { version = "0.11" }
 binread = "2.2"
 
 # This dependency is not used direcly, but we must enable `custom` feature for it to compile for wasm32 target.

--- a/ic-factory/src/api.rs
+++ b/ic-factory/src/api.rs
@@ -26,6 +26,7 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     /// otherwise, cycles balances of `principal` is returned.
     /// If `principal` does not exists, `None` is returned.
     #[update(trait = true)]
+    #[allow(clippy::needless_lifetimes)]
     fn get_cycles<'a>(&'a self, principal: Option<Principal>) -> AsyncReturn<Option<Nat>> {
         let fut = async move {
             if let Some(principal) = principal {

--- a/ic-factory/src/api.rs
+++ b/ic-factory/src/api.rs
@@ -26,8 +26,7 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     /// otherwise, cycles balances of `principal` is returned.
     /// If `principal` does not exists, `None` is returned.
     #[update(trait = true)]
-    #[allow(clippy::needless_lifetimes)]
-    fn get_cycles<'a>(&'a self, principal: Option<Principal>) -> AsyncReturn<Option<Nat>> {
+    fn get_cycles(&self, principal: Option<Principal>) -> AsyncReturn<Option<Nat>> {
         let fut = async move {
             if let Some(principal) = principal {
                 management::Canister::from(principal)
@@ -261,7 +260,7 @@ pub trait FactoryCanister: Canister + Sized + PreUpdate {
     /// Returns the ICPs transferred to the factory by the caller. This method returns all
     /// not used ICP minus transaction fee.
     #[update(trait = true)]
-    fn refund_icp<'a>(&'a self) -> AsyncReturn<'a, Result<u64, FactoryError>> {
+    fn refund_icp(&self) -> AsyncReturn<Result<u64, FactoryError>> {
         use ic_helpers::ledger::{
             LedgerPrincipalExt, PrincipalId, Subaccount, DEFAULT_TRANSFER_FEE,
         };

--- a/ic-factory/src/error.rs
+++ b/ic-factory/src/error.rs
@@ -38,4 +38,7 @@ pub enum FactoryError {
 
     #[error("failed to create canister: {0}")]
     CanisterCreateFailed(String),
+
+    #[error("factory error: {0}")]
+    GenericError(String),
 }

--- a/ic-helpers/Cargo.toml
+++ b/ic-helpers/Cargo.toml
@@ -8,8 +8,10 @@ default = []
 agent = ["ic-agent", "garcon"]
 
 [dependencies]
-ledger-canister = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
-ic-base-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
+ledger-canister = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
+ic-ledger-core = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
+ic-base-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
+ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
 async-trait = "0.1"
 hex = "0.4"
 ic-cdk = "0.5"
@@ -21,16 +23,15 @@ serde_json = "1.0"
 sha2 = "0.9"
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.2"
-ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
 thiserror = "1.0"
 ic-canister = { path = "../ic-canister/ic-canister", package = "ic-canister" }
 ic-canister-macros = { path = "../ic-canister/ic-canister-macros", package = "ic-canister-macros" }
 ic-storage = { path = "../ic-storage" }
 leb128 = "0.2.5"
-ic-agent = { version = "0.16", optional = true }
+ic-agent = { version = "0.20", optional = true }
 garcon = { version = "0.2", optional = true}
 libsecp256k1 = { version = "0.7", optional = false}
-k256 = { version = "0.10" }
+k256 = { version = "0.11" }
 auto_ops = "0.3"
 crypto-bigint = { version = "0.4", features = ["serde"] }
 num-bigint = "0.4"

--- a/ic-helpers/Cargo.toml
+++ b/ic-helpers/Cargo.toml
@@ -11,7 +11,6 @@ agent = ["ic-agent", "garcon"]
 ledger-canister = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
 ic-ledger-core = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
 ic-base-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
-ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
 async-trait = "0.1"
 hex = "0.4"
 ic-cdk = "0.5"
@@ -23,8 +22,8 @@ serde_json = "1.0"
 sha2 = "0.9"
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.2"
-ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-05-18_18-31"}
-stable-structures = { git = "https://github.com/dfinity/ic" }
+ic-ic00-types = {git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31"}
+stable-structures = { git = "https://github.com/dfinity/ic", branch = "rc--2022-09-11_18-31" }
 thiserror = "1.0"
 ic-canister = { path = "../ic-canister/ic-canister", package = "ic-canister" }
 ic-canister-macros = { path = "../ic-canister/ic-canister-macros", package = "ic-canister-macros" }

--- a/ic-helpers/src/ledger/mod.rs
+++ b/ic-helpers/src/ledger/mod.rs
@@ -1,10 +1,11 @@
 mod principal_ext;
 pub use principal_ext::*;
 
+pub use ic_ledger_core::timestamp::TimeStamp;
 pub use ledger_canister::{
     AccountIdBlob, AccountIdentifier, BinaryAccountBalanceArgs, BlockHeight,
-    LedgerCanisterInitPayload, Memo, SendArgs, Subaccount, TimeStamp, Tokens, TransferArgs,
-    TransferError, DEFAULT_TRANSFER_FEE,
+    LedgerCanisterInitPayload, Memo, SendArgs, Subaccount, Tokens, TransferArgs, TransferError,
+    DEFAULT_TRANSFER_FEE,
 };
 
 pub use ic_base_types::PrincipalId;

--- a/ic-helpers/src/management/canister.rs
+++ b/ic-helpers/src/management/canister.rs
@@ -13,9 +13,7 @@ use ic_base_types::CanisterId;
 use ic_canister::virtual_canister_call;
 use ic_cdk::api::call::RejectionCode;
 use ic_ic00_types::{ECDSAPublicKeyResponse, SignWithECDSAReply};
-use k256::elliptic_curve::AlgorithmParameters;
-use k256::pkcs8::{PublicKeyDocument, SubjectPublicKeyInfo};
-use k256::Secp256k1;
+use k256::pkcs8::{self, AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfo};
 use libsecp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
@@ -443,13 +441,16 @@ pub struct CallSignature {
 pub fn der_encode_pub_key(pk: &Pubkey) -> Vec<u8> {
     let pubkey = PublicKey::parse_slice(pk.as_bytes(), None).expect("not a valid public key");
     let pubkey_bytes_uncompress = pubkey.serialize();
-    let der_encoded_public_key: PublicKeyDocument = SubjectPublicKeyInfo {
-        algorithm: Secp256k1::algorithm_identifier(),
+    let der_encoded_public_key: pkcs8::Document = SubjectPublicKeyInfo {
+        algorithm: AlgorithmIdentifier {
+            oid: ObjectIdentifier::new("1.2.840.10045.2.1")
+                .expect("never fails as it is Secp256 oid"),
+            parameters: Some((&ObjectIdentifier::new("1.3.132.0.10").expect("never fails")).into()),
+        },
         subject_public_key: &pubkey_bytes_uncompress,
     }
     .try_into()
     .expect("not a valid PublicKeyDocument");
-
     der_encoded_public_key.as_ref().into()
 }
 

--- a/ic-helpers/src/management/canister.rs
+++ b/ic-helpers/src/management/canister.rs
@@ -443,9 +443,8 @@ pub fn der_encode_pub_key(pk: &Pubkey) -> Vec<u8> {
     let pubkey_bytes_uncompress = pubkey.serialize();
     let der_encoded_public_key: pkcs8::Document = SubjectPublicKeyInfo {
         algorithm: AlgorithmIdentifier {
-            oid: ObjectIdentifier::new("1.2.840.10045.2.1")
-                .expect("never fails as it is Secp256 oid"),
-            parameters: Some((&ObjectIdentifier::new("1.3.132.0.10").expect("never fails")).into()),
+            oid: ObjectIdentifier::new_unwrap("1.2.840.10045.2.1"),
+            parameters: Some((&ObjectIdentifier::new_unwrap("1.3.132.0.10")).into()),
         },
         subject_public_key: &pubkey_bytes_uncompress,
     }

--- a/ic-helpers/src/pair/mod.rs
+++ b/ic-helpers/src/pair/mod.rs
@@ -16,8 +16,10 @@ impl Standard {
             Self::Erc20 => "erc20",
         }
     }
+}
 
-    pub fn from_str(s: &str) -> Self {
+impl From<&str> for Standard {
+    fn from(s: &str) -> Self {
         match s {
             "ledger" => Self::Ledger,
             "erc20" => Self::Erc20,

--- a/ic-stable-storage/Cargo.toml
+++ b/ic-stable-storage/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "=0.7.14"
+candid = "0.7"
 stable-structures = { git = "https://github.com/dfinity/ic" }
 thiserror = "1.0.32"


### PR DESCRIPTION
Currently there is a bug when trying to deploy v1-amm:

```
Error: The Replica returned an error: code 5, message: "Wasm module of canister rrkah-fqaaa-aaaaa-aaaaq-cai is not valid: Wasm module has an invalid import section. Module imports function '__wbindgen_describe' from '__wbindgen_placeholder__' that is not exported by the runtime."
``` 

That is because ic devs have inconsistent versioning in their codebase. We've decided to upgrade the ic dependencies to be able to use their canisters further.
