### PR TITLE
Remove debug outputs for auction by default

### DIFF
--- a/ic-auction/Cargo.toml
+++ b/ic-auction/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 export-api = []
 
 # Add debug outputs for the canister
-debug = []
+debug-logs = []
 
 [dependencies]
 candid = "0.8"

--- a/ic-auction/Cargo.toml
+++ b/ic-auction/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 default = []
 export-api = []
 
+# Add debug outputs for the canister
+debug = []
+
 [dependencies]
 candid = "0.8"
 serde = "1.0"

--- a/ic-auction/src/api.rs
+++ b/ic-auction/src/api.rs
@@ -15,12 +15,12 @@ pub trait Auction: Canister + Sized {
 
     fn canister_pre_update(&self, method_name: &str, _method_type: ic_canister::MethodType) {
         if method_name == "run_auction" {
+            #[cfg(feature = "debug-logs")]
             if !self.auction_state().borrow().bidding_state.is_auction_due() {
-                #[cfg(feature = "debug")]
                 ic_cdk::println!("Too early to begin auction");
             }
         } else if let Err(_auction_error) = self.run_auction() {
-            #[cfg(feature = "debug")]
+            #[cfg(feature = "debug-logs")]
             ic_cdk::println!("Auction error: {_auction_error:#?}");
         }
     }

--- a/ic-auction/src/api.rs
+++ b/ic-auction/src/api.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use ic_canister::{generate_exports, generate_idl, state_getter, update, Canister, Idl, PreUpdate};
-use ic_exports::ic_cdk::{self, export::candid::Principal};
+use ic_exports::ic_cdk::export::candid::Principal;
 use ic_metrics::Interval;
 
 use crate::{
@@ -16,10 +16,12 @@ pub trait Auction: Canister + Sized {
     fn canister_pre_update(&self, method_name: &str, _method_type: ic_canister::MethodType) {
         if method_name == "run_auction" {
             if !self.auction_state().borrow().bidding_state.is_auction_due() {
+                #[cfg(feature = "debug")]
                 ic_cdk::println!("Too early to begin auction");
             }
-        } else if let Err(auction_error) = self.run_auction() {
-            ic_cdk::println!("Auction error: {auction_error:#?}");
+        } else if let Err(_auction_error) = self.run_auction() {
+            #[cfg(feature = "debug")]
+            ic_cdk::println!("Auction error: {_auction_error:#?}");
         }
     }
 


### PR DESCRIPTION
These outputes are very enoying especially in integration tests, but can be usefull for debugging. So I added a `debug` feature to add them when needed.