### PR TITLE
EPROD 381 Stable structs get corrupted after upgrade

### DIFF
--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -57,4 +57,29 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --timeout 120 --out Xml --workspace --exclude canister-a --exclude canister-b --exclude canister-c --exclude canister-d --exclude canister-e --exclude test-payment-canister
+          cargo +nightly tarpaulin --verbose --timeout 120 --out Xml --workspace  --exclude canister-a --exclude canister-b --exclude canister-c --exclude canister-d --exclude canister-e --exclude test-payment-canister
+
+  integration-test:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Machine setup
+        run: |
+          sudo apt update 
+          sudo apt install -y libunwind-dev cmake protobuf-compiler
+          sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+          rustup target add wasm32-unknown-unknown
+          cargo install ic-wasm
+          dfx start --background
+          dfx canister create dummy_canister
+          dfx build dummy_canister
+          ic-payments/build_payments_canister.sh
+
+      - name: Run integration tests
+        run: |
+          export WASMS_DIR="../target/wasm32-unknown-unknown/release/"
+          cd ./ic-stable-structures
+          cargo test --features state-machine

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = [
     "ic-payments",
     "ic-payments/test-payment-canister",
     "ic-stable-structures",
+    "ic-stable-structures/tests/did",
+    "ic-stable-structures/tests/dummy_canister",
     "ic-storage",
     "ic-storage/ic-storage-derive",
 ]

--- a/dfx.json
+++ b/dfx.json
@@ -1,41 +1,47 @@
 {
-      "canisters": {
-            "canister-a": {
-                  "build": "bash scripts/build.sh",
-                  "candid": "ic-canister/tests/canister_a/canister_a.did",
-                  "wasm": "target/wasm32-unknown-unknown/release/canister_a.wasm",
-                  "type": "custom"
-            },
-            "canister-b": {
-                  "build": "bash scripts/build.sh",
-                  "candid": "ic-canister/tests/canister_b/canister_b.did",
-                  "wasm": "target/wasm32-unknown-unknown/release/canister_b.wasm",
-                  "type": "custom"
-            },
-            "canister-c": {
-                  "build": "bash scripts/build.sh",
-                  "candid": "ic-canister/tests/canister-c/canister-c.did",
-                  "wasm": "target/wasm32-unknown-unknown/release/canister-c.wasm",
-                  "type": "custom"
-            },
-            "canister-d": {
-                  "build": "bash scripts/build.sh",
-                  "candid": "ic-canister/tests/canister-d/canister-d.did",
-                  "wasm": "target/wasm32-unknown-unknown/release/canister-d.wasm",
-                  "type": "custom"
-            },
-            "log_canister": {
-              "candid": "ic-log/examples/log_canister.did",
-              "build": "bash scripts/build_log_canister.sh",
-              "wasm": "target/wasm32-unknown-unknown/release/examples/log_canister.wasm",
-              "type": "custom"
-            }
-      },
-      "networks": {
-            "local": {
-                  "bind": "127.0.0.1:8000",
-                  "type": "ephemeral"
-            }
-      },
-      "version": 1
+  "canisters": {
+    "canister-a": {
+      "build": "bash scripts/build.sh",
+      "candid": "ic-canister/tests/canister_a/canister_a.did",
+      "wasm": "target/wasm32-unknown-unknown/release/canister_a.wasm",
+      "type": "custom"
+    },
+    "canister-b": {
+      "build": "bash scripts/build.sh",
+      "candid": "ic-canister/tests/canister_b/canister_b.did",
+      "wasm": "target/wasm32-unknown-unknown/release/canister_b.wasm",
+      "type": "custom"
+    },
+    "canister-c": {
+      "build": "bash scripts/build.sh",
+      "candid": "ic-canister/tests/canister-c/canister-c.did",
+      "wasm": "target/wasm32-unknown-unknown/release/canister-c.wasm",
+      "type": "custom"
+    },
+    "canister-d": {
+      "build": "bash scripts/build.sh",
+      "candid": "ic-canister/tests/canister-d/canister-d.did",
+      "wasm": "target/wasm32-unknown-unknown/release/canister-d.wasm",
+      "type": "custom"
+    },
+    "dummy_canister": {
+      "candid": "ic-stable-structures/tests/dummy_canister/dummy_canister.did",
+      "build": "bash scripts/build_dummy_canister.sh",
+      "wasm": "target/wasm32-unknown-unknown/release/dummy_canister.wasm",
+      "type": "custom"
+    },
+    "log_canister": {
+      "candid": "ic-log/examples/log_canister.did",
+      "build": "bash scripts/build_log_canister.sh",
+      "wasm": "target/wasm32-unknown-unknown/release/examples/log_canister.wasm",
+      "type": "custom"
+    }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:8000",
+      "type": "ephemeral"
+    }
+  },
+  "version": 1
 }

--- a/ic-payments/build_payments_canister.sh
+++ b/ic-payments/build_payments_canister.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+export PROTOC_INCLUDE=${PWD}/../
+
+# Get example icrc1 canister
+if [ ! -f ic-payments/tests/common/ic-icrc1-ledger.wasm ]; then
+    export IC_VERSION=b43543ce7365acd1720294e701e8e8361fa30c8f
+    curl -o ic-icrc1-ledger.wasm.gz https://download.dfinity.systems/ic/${IC_VERSION}/canisters/ic-icrc1-ledger.wasm.gz
+    gunzip ic-icrc1-ledger.wasm.gz
+    mv ic-icrc1-ledger.wasm ic-payments/tests/common/
+fi
+
+# Build test payment canister
+cargo build --target wasm32-unknown-unknown --features export-api -p test-payment-canister --release
+ic-wasm target/wasm32-unknown-unknown/release/test_payment_canister.wasm -o ic-payments/tests/common/payment_canister.wasm shrink

--- a/ic-payments/state_machine_test.sh
+++ b/ic-payments/state_machine_test.sh
@@ -1,22 +1,10 @@
+#!/bin/sh
+
 # Example script to run the state_machine tests. To make it work, replace
 # the location of google protobuf repo in your system. You can find the
 # needed repo at https://github.com/protocolbuffers/protobuf/tree/main/src/google/protobuf
 
-set -e
-
-export PROTOC_INCLUDE=${PWD}/../
-
-# Get example icrc1 canister
-if [ ! -f ic-payments/tests/common/ic-icrc1-ledger.wasm ]; then
-    export IC_VERSION=b43543ce7365acd1720294e701e8e8361fa30c8f
-    curl -o ic-icrc1-ledger.wasm.gz https://download.dfinity.systems/ic/${IC_VERSION}/canisters/ic-icrc1-ledger.wasm.gz
-    gunzip ic-icrc1-ledger.wasm.gz
-    mv ic-icrc1-ledger.wasm ic-payments/tests/common/
-fi
-
-# Build test payment canister
-cargo build --target wasm32-unknown-unknown --features export-api -p test-payment-canister --release
-ic-wasm target/wasm32-unknown-unknown/release/test_payment_canister.wasm -o ic-payments/tests/common/payment_canister.wasm shrink
+./build_payments_canister.sh
 
 # Run the test
 cargo +nightly test -p ic-payments --features state-machine

--- a/ic-stable-structures/Cargo.toml
+++ b/ic-stable-structures/Cargo.toml
@@ -6,3 +6,16 @@ edition.workspace = true
 [dependencies]
 ic-exports = { path = "../ic-exports" }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+anyhow = "1"
+candid = { workspace = true }
+did = { path = "./tests/did" }
+ic-cdk = { workspace = true }
+ic-cdk-macros = { workspace = true }
+once_cell = "1.18"
+serde = { workspace = true }
+
+
+[features]
+state-machine = ["ic-exports/state-machine"]

--- a/ic-stable-structures/src/storage/structures/vec.rs
+++ b/ic-stable-structures/src/storage/structures/vec.rs
@@ -29,7 +29,7 @@ impl<T: BoundedStorable> StableVec<T> {
         self.get_inner().map_or(true, InnerVec::is_empty)
     }
 
-    /// Removes al the values from the vector
+    /// Removes all the values from the vector
     pub fn clear(&mut self) -> Result<()> {
         let memory_id = self.memory_id;
         if let Some(vec) = self.mut_inner() {

--- a/ic-stable-structures/src/storage_wasm/structures_wasm.rs
+++ b/ic-stable-structures/src/storage_wasm/structures_wasm.rs
@@ -192,7 +192,7 @@ impl<T: Storable> StableLog<T> {
         let index_memory = crate::get_memory_by_id(index_memory_id);
         let data_memory = crate::get_memory_by_id(data_memory_id);
 
-        let inner = log::Log::new(index_memory, data_memory);
+        let inner = log::Log::init(index_memory, data_memory)?;
         Ok(Self(Some(inner)))
     }
 
@@ -308,7 +308,7 @@ impl<T: BoundedStorable> StableVec<T> {
     /// Creates new `StableVec`
     pub fn new(memory_id: MemoryId) -> Result<Self> {
         Ok(Self(
-            vec::Vec::<T, Memory>::new(get_memory_by_id(memory_id))?,
+            vec::Vec::<T, Memory>::init(get_memory_by_id(memory_id))?,
             memory_id,
         ))
     }

--- a/ic-stable-structures/tests/did/Cargo.toml
+++ b/ic-stable-structures/tests/did/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "did"
+version.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+
+[dependencies]
+candid = { workspace = true }
+ic-stable-structures = { path = "../../../ic-stable-structures" }
+serde = { workspace = true }

--- a/ic-stable-structures/tests/did/src/lib.rs
+++ b/ic-stable-structures/tests/did/src/lib.rs
@@ -1,0 +1,36 @@
+use candid::{CandidType, Decode, Deserialize, Encode};
+use ic_stable_structures::{BoundedStorable, ChunkSize, SlicedStorable, Storable};
+
+pub fn encode(item: &impl CandidType) -> Vec<u8> {
+    Encode!(item).expect("failed to encode item to candid")
+}
+
+pub fn decode<'a, T: CandidType + Deserialize<'a>>(bytes: &'a [u8]) -> T {
+    Decode!(bytes, T).expect("failed to decode item from candid")
+}
+
+#[derive(Debug, Default, Clone, Copy, CandidType, Deserialize)]
+pub struct Transaction {
+    pub from: u8,
+    pub to: u8,
+    pub value: u8,
+}
+
+impl Storable for Transaction {
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        encode(self).into()
+    }
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        decode(&bytes)
+    }
+}
+
+impl SlicedStorable for Transaction {
+    const CHUNK_SIZE: ChunkSize = 8;
+}
+
+impl BoundedStorable for Transaction {
+    const MAX_SIZE: u32 = 32;
+    const IS_FIXED_SIZE: bool = false;
+}

--- a/ic-stable-structures/tests/dummy_canister/.gitignore
+++ b/ic-stable-structures/tests/dummy_canister/.gitignore
@@ -1,0 +1,1 @@
+!dummy_canister.did

--- a/ic-stable-structures/tests/dummy_canister/Cargo.toml
+++ b/ic-stable-structures/tests/dummy_canister/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dummy_canister"
+version.workspace = true
+edition.workspace = true
+
+[features]
+default = []
+export-api = []
+
+[dependencies]
+candid = { workspace = true }
+did = { path = "../did" }
+ic-canister = { path = "../../../ic-canister/ic-canister" }
+ic-cdk = { workspace = true }
+ic-exports = { path = "../../../ic-exports" }
+ic-stable-structures = { path = "../../../ic-stable-structures" }
+serde = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/ic-stable-structures/tests/dummy_canister/dummy_canister.did
+++ b/ic-stable-structures/tests/dummy_canister/dummy_canister.did
@@ -1,0 +1,15 @@
+type Transaction = record { to : nat8; value : nat8; from : nat8 };
+service : () -> {
+  get_tx_from_btreemap : (nat64) -> (opt Transaction) query;
+  get_tx_from_cell : () -> (Transaction) query;
+  get_tx_from_log : (nat64) -> (opt Transaction) query;
+  get_tx_from_map : (nat64) -> (opt Transaction) query;
+  get_tx_from_multimap : (nat64) -> (opt Transaction) query;
+  get_tx_from_vec : (nat64) -> (opt Transaction) query;
+  insert_tx_to_btreemap : (Transaction) -> (nat64);
+  insert_tx_to_cell : (Transaction) -> ();
+  insert_tx_to_map : (Transaction) -> (nat64);
+  insert_tx_to_multimap : (Transaction) -> (nat64);
+  push_tx_to_log : (Transaction) -> (nat64);
+  push_tx_to_vec : (Transaction) -> (nat64);
+}

--- a/ic-stable-structures/tests/dummy_canister/src/canister.rs
+++ b/ic-stable-structures/tests/dummy_canister/src/canister.rs
@@ -1,0 +1,86 @@
+use candid::Principal;
+use did::Transaction;
+use ic_canister::{generate_idl, init, query, update, Canister, Idl, PreUpdate};
+
+use service::Service;
+
+mod service;
+
+#[derive(Canister)]
+pub struct DummyCanister {
+    #[id]
+    id: Principal,
+}
+
+impl PreUpdate for DummyCanister {}
+
+impl DummyCanister {
+    #[init]
+    pub fn init(&self) {
+        Service::init()
+    }
+
+    #[query]
+    pub fn get_tx_from_btreemap(&self, key: u64) -> Option<Transaction> {
+        Service::get_tx_from_btreemap(key)
+    }
+
+    #[update]
+    pub async fn insert_tx_to_btreemap(&self, transaction: Transaction) -> u64 {
+        Service::insert_tx_to_btreemap(transaction)
+    }
+
+    #[query]
+    pub fn get_tx_from_cell(&self) -> Transaction {
+        Service::get_tx_from_cell()
+    }
+
+    #[update]
+    pub async fn insert_tx_to_cell(&self, transaction: Transaction) {
+        Service::insert_tx_to_cell(transaction)
+    }
+
+    #[query]
+    pub fn get_tx_from_log(&self, idx: u64) -> Option<Transaction> {
+        Service::get_tx_from_log(idx)
+    }
+
+    #[update]
+    pub async fn push_tx_to_log(&self, transaction: Transaction) -> u64 {
+        Service::push_tx_to_log(transaction)
+    }
+
+    #[query]
+    pub fn get_tx_from_map(&self, key: u64) -> Option<Transaction> {
+        Service::get_tx_from_map(key)
+    }
+
+    #[update]
+    pub async fn insert_tx_to_map(&self, transaction: Transaction) -> u64 {
+        Service::insert_tx_to_map(transaction)
+    }
+
+    #[query]
+    pub fn get_tx_from_multimap(&self, key: u64) -> Option<Transaction> {
+        Service::get_tx_from_multimap(key)
+    }
+
+    #[update]
+    pub async fn insert_tx_to_multimap(&self, transaction: Transaction) -> u64 {
+        Service::insert_tx_to_multimap(transaction)
+    }
+
+    #[query]
+    pub fn get_tx_from_vec(&self, idx: u64) -> Option<Transaction> {
+        Service::get_tx_from_vec(idx)
+    }
+
+    #[update]
+    pub async fn push_tx_to_vec(&self, transaction: Transaction) -> u64 {
+        Service::push_tx_to_vec(transaction)
+    }
+
+    pub fn idl() -> Idl {
+        generate_idl!()
+    }
+}

--- a/ic-stable-structures/tests/dummy_canister/src/canister/service.rs
+++ b/ic-stable-structures/tests/dummy_canister/src/canister/service.rs
@@ -1,0 +1,175 @@
+use ic_stable_structures::{
+    MemoryId, StableBTreeMap, StableCell, StableLog, StableMultimap, StableUnboundedMap, StableVec,
+};
+use std::cell::RefCell;
+
+use did::Transaction;
+
+const TX_MAP_MEMORY_ID: MemoryId = MemoryId::new(1);
+const TX_VEC_MEMORY_ID: MemoryId = MemoryId::new(2);
+const TX_LOG_INDEX_MEMORY_ID: MemoryId = MemoryId::new(3);
+const TX_LOG_MEMORY_ID: MemoryId = MemoryId::new(4);
+const TX_CELL_MEMORY_ID: MemoryId = MemoryId::new(5);
+const TX_BTREEMAP_MEMORY_ID: MemoryId = MemoryId::new(6);
+const TX_MULTIMAP_MEMORY_ID: MemoryId = MemoryId::new(7);
+
+thread_local! {
+
+    static TX_BTREEMAP: RefCell<StableBTreeMap<u64, Transaction>> = {
+        RefCell::new(StableBTreeMap::new(TX_BTREEMAP_MEMORY_ID))
+    };
+
+    static TX_CELL: RefCell<StableCell<Transaction>> = {
+        RefCell::new(StableCell::new(TX_CELL_MEMORY_ID, Transaction::default()).expect("failed to create stable cell"))
+    };
+
+    static TX_LOG: RefCell<StableLog<Transaction>> = {
+        RefCell::new(StableLog::new(TX_LOG_INDEX_MEMORY_ID, TX_LOG_MEMORY_ID).expect("failed to create stable log"))
+    };
+
+    static TX_MAP: RefCell<StableUnboundedMap<u64, Transaction>> = {
+        RefCell::new(StableUnboundedMap::new(TX_MAP_MEMORY_ID))
+    };
+
+    static TX_MULTIMAP: RefCell<StableMultimap<u64, u64, Transaction>> = {
+        RefCell::new(StableMultimap::new(TX_MULTIMAP_MEMORY_ID))
+    };
+
+    static TX_VEC: RefCell<StableVec<Transaction>> = {
+        RefCell::new(StableVec::new(TX_VEC_MEMORY_ID).expect("failed to create stable vec"))
+    };
+
+
+}
+
+#[derive(Default)]
+pub struct Service;
+
+impl Service {
+    pub fn init() {
+        let should_init_btreemap = TX_BTREEMAP.with(|txs| txs.borrow().len()) == 0;
+        if should_init_btreemap {
+            Self::insert_tx_to_btreemap(Transaction {
+                from: 0,
+                to: 0,
+                value: 0,
+            });
+        }
+        let should_init_map = TX_MAP.with(|txs| txs.borrow().len()) == 0;
+        if should_init_map {
+            Self::insert_tx_to_map(Transaction {
+                from: 0,
+                to: 0,
+                value: 0,
+            });
+        }
+        let should_init_multimap = TX_MULTIMAP.with(|txs| txs.borrow().len()) == 0;
+        if should_init_multimap {
+            Self::insert_tx_to_multimap(Transaction {
+                from: 0,
+                to: 0,
+                value: 0,
+            });
+        }
+        let should_init_vec = TX_VEC.with(|txs| txs.borrow().len()) == 0;
+        if should_init_vec {
+            Self::push_tx_to_vec(Transaction {
+                from: 0,
+                to: 0,
+                value: 0,
+            });
+        }
+        let should_init_log = TX_LOG.with(|txs| txs.borrow().len()) == 0;
+        if should_init_log {
+            Self::push_tx_to_log(Transaction {
+                from: 0,
+                to: 0,
+                value: 0,
+            });
+        }
+    }
+
+    pub fn get_tx_from_btreemap(key: u64) -> Option<Transaction> {
+        TX_BTREEMAP.with(|tx| tx.borrow().get(&key))
+    }
+
+    pub fn insert_tx_to_btreemap(transaction: Transaction) -> u64 {
+        TX_BTREEMAP.with(|storage| {
+            let new_key = storage.borrow().len();
+            storage.borrow_mut().insert(new_key, transaction);
+
+            new_key
+        })
+    }
+
+    pub fn get_tx_from_cell() -> Transaction {
+        TX_CELL.with(|tx| tx.borrow().get().clone())
+    }
+
+    pub fn insert_tx_to_cell(transaction: Transaction) {
+        TX_CELL.with(|storage| {
+            storage
+                .borrow_mut()
+                .set(transaction)
+                .expect("failed to push to cell");
+        })
+    }
+
+    pub fn get_tx_from_log(idx: u64) -> Option<Transaction> {
+        TX_LOG.with(|tx| tx.borrow().get(idx))
+    }
+
+    pub fn push_tx_to_log(transaction: Transaction) -> u64 {
+        TX_LOG.with(|storage| {
+            storage
+                .borrow_mut()
+                .append(transaction)
+                .expect("failed to push to log");
+
+            storage.borrow().len()
+        })
+    }
+
+    pub fn get_tx_from_map(key: u64) -> Option<Transaction> {
+        TX_MAP.with(|tx| tx.borrow().get(&key))
+    }
+
+    pub fn insert_tx_to_map(transaction: Transaction) -> u64 {
+        TX_MAP.with(|storage| {
+            let new_key = storage.borrow().len();
+            storage.borrow_mut().insert(&new_key, &transaction);
+
+            new_key
+        })
+    }
+
+    pub fn get_tx_from_multimap(key: u64) -> Option<Transaction> {
+        TX_MULTIMAP.with(|tx| tx.borrow().get(&key, &(key + 1)))
+    }
+
+    pub fn insert_tx_to_multimap(transaction: Transaction) -> u64 {
+        TX_MULTIMAP.with(|storage| {
+            let new_key = storage.borrow().len() as u64;
+            storage
+                .borrow_mut()
+                .insert(&new_key, &(new_key + 1), &transaction);
+
+            new_key
+        })
+    }
+
+    pub fn get_tx_from_vec(idx: u64) -> Option<Transaction> {
+        TX_VEC.with(|tx| tx.borrow().get(idx))
+    }
+
+    pub fn push_tx_to_vec(transaction: Transaction) -> u64 {
+        TX_VEC.with(|storage| {
+            storage
+                .borrow_mut()
+                .push(&transaction)
+                .expect("failed to push to vec");
+
+            storage.borrow().len()
+        })
+    }
+}

--- a/ic-stable-structures/tests/dummy_canister/src/main.rs
+++ b/ic-stable-structures/tests/dummy_canister/src/main.rs
@@ -1,0 +1,11 @@
+pub mod canister;
+
+use canister::DummyCanister;
+
+fn main() {
+    let canister_e_idl = DummyCanister::idl();
+    let idl =
+        candid::bindings::candid::compile(&canister_e_idl.env.env, &Some(canister_e_idl.actor));
+
+    println!("{}", idl);
+}

--- a/ic-stable-structures/tests/integration_test.rs
+++ b/ic-stable-structures/tests/integration_test.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "state-machine")]
+mod state_machine;
+
+mod utils;

--- a/ic-stable-structures/tests/state_machine/btreemap.rs
+++ b/ic-stable-structures/tests/state_machine/btreemap.rs
@@ -1,0 +1,39 @@
+use super::with_state_machine_context;
+
+#[test]
+fn should_init_tx_btreemap() {
+    with_state_machine_context(|_, ctx| {
+        assert!(ctx.get_tx_from_btreemap(0)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_push_tx_to_btreemap() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_btreemap(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_btreemap(1).unwrap().is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_persist_btreemap_tx_after_upgrade() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_btreemap(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_btreemap(1)?.is_some());
+
+        super::upgrade_dummy_canister(ctx)?;
+
+        assert!(ctx.get_tx_from_btreemap(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ic-stable-structures/tests/state_machine/cell.rs
+++ b/ic-stable-structures/tests/state_machine/cell.rs
@@ -1,0 +1,39 @@
+use super::with_state_machine_context;
+
+#[test]
+fn should_init_tx_cell() {
+    with_state_machine_context(|_, ctx| {
+        assert_eq!(ctx.get_tx_from_cell()?.from, 0);
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_push_tx_to_cell() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_cell(1, 1, 10)?;
+
+        assert_eq!(ctx.get_tx_from_cell()?.from, 1);
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_persist_cell_tx_after_upgrade() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_cell(1, 1, 10)?;
+
+        assert_eq!(ctx.get_tx_from_cell()?.from, 1);
+
+        super::upgrade_dummy_canister(ctx)?;
+
+        assert_eq!(ctx.get_tx_from_cell()?.from, 1);
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ic-stable-structures/tests/state_machine/log.rs
+++ b/ic-stable-structures/tests/state_machine/log.rs
@@ -1,0 +1,40 @@
+use super::with_state_machine_context;
+
+#[test]
+fn should_init_tx_log() {
+    with_state_machine_context(|_, ctx| {
+        let res = ctx.get_tx_from_log(0)?;
+        assert!(res.is_some());
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_push_tx_to_log() {
+    with_state_machine_context(|_, ctx| {
+        ctx.push_tx_to_log(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_log(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_persist_log_tx_after_upgrade() {
+    with_state_machine_context(|_, ctx| {
+        ctx.push_tx_to_log(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_log(1)?.is_some());
+
+        super::upgrade_dummy_canister(ctx)?;
+
+        assert!(ctx.get_tx_from_log(0)?.is_some());
+        assert!(ctx.get_tx_from_log(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ic-stable-structures/tests/state_machine/map.rs
+++ b/ic-stable-structures/tests/state_machine/map.rs
@@ -1,0 +1,40 @@
+use super::with_state_machine_context;
+
+#[test]
+fn should_init_tx_map() {
+    with_state_machine_context(|_, ctx| {
+        assert!(ctx.get_tx_from_map(0)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_push_tx_to_map() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_map(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_map(1).unwrap().is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_persist_map_tx_after_upgrade() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_map(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_map(1)?.is_some());
+
+        super::upgrade_dummy_canister(ctx)?;
+
+        assert!(ctx.get_tx_from_map(0)?.is_some());
+        assert!(ctx.get_tx_from_map(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ic-stable-structures/tests/state_machine/mod.rs
+++ b/ic-stable-structures/tests/state_machine/mod.rs
@@ -1,0 +1,258 @@
+use std::sync::Mutex;
+
+use anyhow::Result;
+use candid::{Decode, Encode};
+use did::Transaction;
+use ic_exports::ic_kit::ic;
+use ic_exports::ic_kit::inject;
+use ic_exports::ic_kit::mock_principals::alice;
+use ic_exports::ic_state_machine_tests::{CanisterId, Cycles, StateMachine};
+use once_cell::sync::Lazy;
+
+use crate::utils::wasm::get_dummy_canister_bytecode;
+
+mod btreemap;
+mod cell;
+mod log;
+mod map;
+mod multimap;
+mod vec;
+
+#[derive(Debug)]
+pub struct StateMachineTestContext {
+    pub env: StateMachine,
+    pub dummy_canister: CanisterId,
+}
+
+impl StateMachineTestContext {
+    pub fn get_tx_from_btreemap(&self, key: u64) -> Result<Option<Transaction>> {
+        let args = Encode!(&key).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "get_tx_from_btreemap",
+            args,
+        )?;
+
+        let tx = Decode!(&res.bytes(), Option<Transaction>)?;
+
+        Ok(tx)
+    }
+
+    pub fn insert_tx_to_btreemap(&self, from: u8, to: u8, value: u8) -> Result<u64> {
+        let args = Encode!(&Transaction { from, to, value }).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "insert_tx_to_btreemap",
+            args,
+        )?;
+
+        let key = Decode!(&res.bytes(), u64)?;
+
+        Ok(key)
+    }
+
+    pub fn get_tx_from_cell(&self) -> Result<Transaction> {
+        let args = Encode!(&()).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "get_tx_from_cell",
+            args,
+        )?;
+
+        let tx = Decode!(&res.bytes(), Transaction)?;
+
+        Ok(tx)
+    }
+
+    pub fn insert_tx_to_cell(&self, from: u8, to: u8, value: u8) -> Result<()> {
+        let args = Encode!(&Transaction { from, to, value }).unwrap();
+        self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "insert_tx_to_cell",
+            args,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn get_tx_from_map(&self, key: u64) -> Result<Option<Transaction>> {
+        let args = Encode!(&key).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "get_tx_from_map",
+            args,
+        )?;
+
+        let tx = Decode!(&res.bytes(), Option<Transaction>)?;
+
+        Ok(tx)
+    }
+
+    pub fn insert_tx_to_map(&self, from: u8, to: u8, value: u8) -> Result<u64> {
+        let args = Encode!(&Transaction { from, to, value }).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "insert_tx_to_map",
+            args,
+        )?;
+
+        let key = Decode!(&res.bytes(), u64)?;
+
+        Ok(key)
+    }
+
+    pub fn get_tx_from_multimap(&self, key: u64) -> Result<Option<Transaction>> {
+        let args = Encode!(&key).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "get_tx_from_multimap",
+            args,
+        )?;
+
+        let tx = Decode!(&res.bytes(), Option<Transaction>)?;
+
+        Ok(tx)
+    }
+
+    pub fn insert_tx_to_multimap(&self, from: u8, to: u8, value: u8) -> Result<u64> {
+        let args = Encode!(&Transaction { from, to, value }).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "insert_tx_to_multimap",
+            args,
+        )?;
+
+        let key = Decode!(&res.bytes(), u64)?;
+
+        Ok(key)
+    }
+
+    pub fn get_tx_from_vec(&self, index: u64) -> Result<Option<Transaction>> {
+        let args = Encode!(&index).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "get_tx_from_vec",
+            args,
+        )?;
+
+        let tx = Decode!(&res.bytes(), Option<Transaction>)?;
+
+        Ok(tx)
+    }
+
+    pub fn push_tx_to_vec(&self, from: u8, to: u8, value: u8) -> Result<u64> {
+        let args = Encode!(&Transaction { from, to, value }).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "push_tx_to_vec",
+            args,
+        )?;
+
+        let key = Decode!(&res.bytes(), u64)?;
+
+        Ok(key)
+    }
+
+    pub fn get_tx_from_log(&self, index: u64) -> Result<Option<Transaction>> {
+        let args = Encode!(&index).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "get_tx_from_log",
+            args,
+        )?;
+
+        let tx = Decode!(&res.bytes(), Option<Transaction>)?;
+
+        Ok(tx)
+    }
+
+    pub fn push_tx_to_log(&self, from: u8, to: u8, value: u8) -> Result<u64> {
+        let args = Encode!(&Transaction { from, to, value }).unwrap();
+        let res = self.env.execute_ingress_as(
+            ic::caller().into(),
+            self.dummy_canister,
+            "push_tx_to_log",
+            args,
+        )?;
+
+        let key = Decode!(&res.bytes(), u64)?;
+
+        Ok(key)
+    }
+}
+
+pub fn with_state_machine_context<'a, F>(f: F) -> Result<()>
+where
+    F: FnOnce(&'a mut ic_exports::ic_kit::MockContext, &StateMachineTestContext) -> Result<()>,
+{
+    ic_exports::ic_kit::MockContext::new()
+        .with_caller(alice())
+        .with_id(alice())
+        .inject();
+
+    static TEST_CONTEXT: Lazy<Mutex<StateMachineTestContext>> = Lazy::new(|| {
+        let env = StateMachine::new();
+        let dummy_canister = deploy_dummy_canister(&env).unwrap();
+        StateMachineTestContext {
+            env,
+            dummy_canister,
+        }
+        .into()
+    });
+    let test_ctx = TEST_CONTEXT.lock().unwrap();
+    let ctx = inject::get_context();
+
+    f(ctx, &test_ctx)?;
+
+    reinstall_dummy_canister(&test_ctx)?;
+
+    Ok(())
+}
+
+fn deploy_dummy_canister(env: &StateMachine) -> Result<CanisterId> {
+    let dummy_wasm = get_dummy_canister_bytecode();
+    eprintln!("Creating dummy canister");
+
+    let args = Encode!(&())?;
+    let canister = env.install_canister_with_cycles(
+        dummy_wasm.to_vec(),
+        args,
+        None,
+        Cycles::new(10_u128.pow(12)),
+    )?;
+
+    Ok(canister)
+}
+
+pub fn reinstall_dummy_canister(ctx: &StateMachineTestContext) -> Result<()> {
+    let args = Encode!(&())?;
+
+    let dummy_wasm = get_dummy_canister_bytecode();
+
+    ctx.env
+        .reinstall_canister(ctx.dummy_canister, dummy_wasm, args)?;
+
+    Ok(())
+}
+
+pub fn upgrade_dummy_canister(ctx: &StateMachineTestContext) -> Result<()> {
+    let args = Encode!(&())?;
+
+    let dummy_wasm = get_dummy_canister_bytecode();
+
+    ctx.env
+        .upgrade_canister(ctx.dummy_canister, dummy_wasm, args)?;
+
+    Ok(())
+}

--- a/ic-stable-structures/tests/state_machine/multimap.rs
+++ b/ic-stable-structures/tests/state_machine/multimap.rs
@@ -1,0 +1,40 @@
+use super::with_state_machine_context;
+
+#[test]
+fn should_init_tx_multimap() {
+    with_state_machine_context(|_, ctx| {
+        assert!(ctx.get_tx_from_multimap(0)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_push_tx_to_multimap() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_multimap(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_multimap(1).unwrap().is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_persist_multimap_tx_after_upgrade() {
+    with_state_machine_context(|_, ctx| {
+        ctx.insert_tx_to_multimap(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_multimap(1)?.is_some());
+
+        super::upgrade_dummy_canister(ctx)?;
+
+        assert!(ctx.get_tx_from_multimap(0)?.is_some());
+        assert!(ctx.get_tx_from_multimap(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ic-stable-structures/tests/state_machine/vec.rs
+++ b/ic-stable-structures/tests/state_machine/vec.rs
@@ -1,0 +1,40 @@
+use super::with_state_machine_context;
+
+#[test]
+fn should_init_tx_vec() {
+    with_state_machine_context(|_, ctx| {
+        let res = ctx.get_tx_from_vec(0)?;
+        assert!(res.is_some());
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_push_tx_to_vec() {
+    with_state_machine_context(|_, ctx| {
+        ctx.push_tx_to_vec(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_vec(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn should_persist_vec_tx_after_upgrade() {
+    with_state_machine_context(|_, ctx| {
+        ctx.push_tx_to_vec(1, 1, 10)?;
+
+        assert!(ctx.get_tx_from_vec(1)?.is_some());
+
+        super::upgrade_dummy_canister(ctx)?;
+
+        assert!(ctx.get_tx_from_vec(0)?.is_some());
+        assert!(ctx.get_tx_from_vec(1)?.is_some());
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/ic-stable-structures/tests/utils/mod.rs
+++ b/ic-stable-structures/tests/utils/mod.rs
@@ -1,0 +1,13 @@
+use std::path::{Path, PathBuf};
+
+pub mod wasm;
+
+/// Returns the Path to the workspace root dir
+pub fn get_workspace_root_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}

--- a/ic-stable-structures/tests/utils/wasm.rs
+++ b/ic-stable-structures/tests/utils/wasm.rs
@@ -1,0 +1,56 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use once_cell::sync::OnceCell;
+
+use super::get_workspace_root_dir;
+
+/// Returns the bytecode of the evmc canister
+pub fn get_dummy_canister_bytecode() -> Vec<u8> {
+    static CANISTER_BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
+    CANISTER_BYTECODE
+        .get_or_init(|| load_wasm_bytecode_or_panic("dummy_canister.wasm"))
+        .to_owned()
+}
+
+fn load_wasm_bytecode_or_panic(wasm_name: &str) -> Vec<u8> {
+    let path = get_path_to_wasm(wasm_name);
+
+    let mut f = File::open(path).expect("File does not exists");
+
+    let mut buffer = Vec::new();
+    f.read_to_end(&mut buffer)
+        .expect("Could not read file content");
+
+    buffer
+}
+
+fn get_path_to_wasm(wasm_name: &str) -> PathBuf {
+    if let Ok(dir_path) = std::env::var("WASMS_DIR") {
+        let wasm_path = Path::new(&dir_path).join(wasm_name);
+
+        if wasm_path.as_path().exists() {
+            return wasm_path;
+        }
+    } else {
+        const ARTIFACT_PATH: &str = ".artifact";
+        // Get to the root of the project
+        let root_dir = get_workspace_root_dir();
+        let wasm_path = root_dir.join(ARTIFACT_PATH).join(wasm_name);
+        if wasm_path.as_path().exists() {
+            return wasm_path;
+        }
+    }
+
+    if let Ok(dir_path) = std::env::var("DFX_WASMS_DIR") {
+        let wasm_path = Path::new(&dir_path).join(wasm_name);
+        if wasm_path.as_path().exists() {
+            return wasm_path;
+        }
+    }
+
+    panic!(
+        "File {wasm_name} was not found in dirs provided by ENV variables WASMS_DIR or DFX_WASMS_DIR or in the '.artifact' folder"
+    );
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,13 +4,16 @@ cargo run -p canister-a --features export-api > ic-canister/tests/canister-a/can
 cargo run -p canister-b --features export-api > ic-canister/tests/canister-b/canister-b.did
 cargo run -p canister-c --features export-api > ic-canister/tests/canister-c/canister-c.did
 cargo run -p canister-d --features export-api > ic-canister/tests/canister-d/canister-d.did
+cargo run -p dummy_canister --features export-api > ic-stable-structures/tests/dummy_canister/dummy_canister.did
 
 cargo build -p canister-a --lib --target wasm32-unknown-unknown --features export-api --release
 cargo build -p canister-b --lib --target wasm32-unknown-unknown --features export-api --release
 cargo build -p canister-c --lib --target wasm32-unknown-unknown --features export-api --release
 cargo build -p canister-d --lib --target wasm32-unknown-unknown --features export-api --release
+cargo build -p dummy_canister --target wasm32-unknown-unknown --features export-api --release
 
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/canister_a.wasm -o target/wasm32-unknown-unknown/release/canister-a.wasm
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/canister_b.wasm -o target/wasm32-unknown-unknown/release/canister-b.wasm
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/canister_c.wasm -o target/wasm32-unknown-unknown/release/canister-c.wasm
 ic-cdk-optimizer target/wasm32-unknown-unknown/release/canister_d.wasm -o target/wasm32-unknown-unknown/release/canister-d.wasm
+

--- a/scripts/build_dummy_canister.sh
+++ b/scripts/build_dummy_canister.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cargo run -p dummy_canister --features export-api > ic-stable-structures/tests/dummy_canister/dummy_canister.did
+cargo build -p dummy_canister --target wasm32-unknown-unknown --features export-api --release
+ic-wasm target/wasm32-unknown-unknown/release/dummy_canister.wasm -o target/wasm32-unknown-unknown/release/dummy_canister.wasm shrink
+gzip -k target/wasm32-unknown-unknown/release/dummy_canister.wasm --force


### PR DESCRIPTION
Run integration test for stable-structures with

```sh
export WASMS_DIR="../target/wasm32-unknown-unknown/release/"
dfx build dummy_canister && cargo test -p ic-stable-structures@0.3.53 --features state-machine
```